### PR TITLE
chore: update module path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The quickest path from opening a pending review to resolving threads:
 1. **Install or upgrade the extension.**
 
    ```sh
-   gh extension install Agynio/gh-pr-review
+   gh extension install agynio/gh-pr-review
    # Update an existing installation
-   gh extension upgrade Agynio/gh-pr-review
+   gh extension upgrade agynio/gh-pr-review
    ```
 
 
@@ -180,9 +180,9 @@ gh pr-review review view -R owner/repo --pr 3
 Install or upgrade to **v1.6.0 or newer** (GraphQL-only thread resolution and minimal comment replies):
 
 ```sh
-gh extension install Agynio/gh-pr-review
+gh extension install agynio/gh-pr-review
 # Update an existing installation
-gh extension upgrade Agynio/gh-pr-review
+gh extension upgrade agynio/gh-pr-review
 ```
 
 ### Command behavior
@@ -336,4 +336,3 @@ CGO_ENABLED=0 golangci-lint run
 Releases are built using the
 [`cli/gh-extension-precompile`](https://github.com/cli/gh-extension-precompile)
 workflow to publish binaries for macOS, Linux, and Windows.
-

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-    "github.com/agynio/gh-pr-review/internal/comments"
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/comments"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 type commentsOptions struct {

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/comments"
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/comments"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 type commentsOptions struct {

--- a/cmd/comments_test.go
+++ b/cmd/comments_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
+    "github.com/agynio/gh-pr-review/internal/ghcli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/comments_test.go
+++ b/cmd/comments_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-    "github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/ghcli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
+import "github.com/agynio/gh-pr-review/internal/ghcli"
 
 var apiClientFactory = func(host string) ghcli.API {
 	return &ghcli.Client{Host: host}

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-    "github.com/agynio/gh-pr-review/internal/resolver"
-    reviewsvc "github.com/agynio/gh-pr-review/internal/review"
+	"github.com/agynio/gh-pr-review/internal/resolver"
+	reviewsvc "github.com/agynio/gh-pr-review/internal/review"
 )
 
 func newReviewCommand() *cobra.Command {

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
-	reviewsvc "github.com/Agyn-sandbox/gh-pr-review/internal/review"
+    "github.com/agynio/gh-pr-review/internal/resolver"
+    reviewsvc "github.com/agynio/gh-pr-review/internal/review"
 )
 
 func newReviewCommand() *cobra.Command {

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"testing"
 
-    "github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/ghcli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
+    "github.com/agynio/gh-pr-review/internal/ghcli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/review_view.go
+++ b/cmd/review_view.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-    "github.com/agynio/gh-pr-review/internal/report"
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/report"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 func newReviewViewCommand() *cobra.Command {

--- a/cmd/review_view.go
+++ b/cmd/review_view.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/report"
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/report"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 func newReviewViewCommand() *cobra.Command {

--- a/cmd/review_view_test.go
+++ b/cmd/review_view_test.go
@@ -9,7 +9,7 @@ import (
 
 	_ "embed"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
+    "github.com/agynio/gh-pr-review/internal/ghcli"
 )
 
 //go:embed testdata/report_response.json

--- a/cmd/review_view_test.go
+++ b/cmd/review_view_test.go
@@ -9,7 +9,7 @@ import (
 
 	_ "embed"
 
-    "github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/ghcli"
 )
 
 //go:embed testdata/report_response.json

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
-	"github.com/Agyn-sandbox/gh-pr-review/internal/threads"
+    "github.com/agynio/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/threads"
 )
 
 func newThreadsCommand() *cobra.Command {

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-    "github.com/agynio/gh-pr-review/internal/resolver"
-    "github.com/agynio/gh-pr-review/internal/threads"
+	"github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/threads"
 )
 
 func newThreadsCommand() *cobra.Command {

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
+    "github.com/agynio/gh-pr-review/internal/ghcli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-    "github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/ghcli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Agyn-sandbox/gh-pr-review
+module github.com/agynio/gh-pr-review
 
 go 1.22
 

--- a/internal/comments/service.go
+++ b/internal/comments/service.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/ghcli"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 const addThreadReplyMutation = `mutation AddPullRequestReviewThreadReply($input: AddPullRequestReviewThreadReplyInput!) {

--- a/internal/comments/service.go
+++ b/internal/comments/service.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"strings"
 
-    "github.com/agynio/gh-pr-review/internal/ghcli"
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 const addThreadReplyMutation = `mutation AddPullRequestReviewThreadReply($input: AddPullRequestReviewThreadReplyInput!) {

--- a/internal/comments/service_test.go
+++ b/internal/comments/service_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/comments/service_test.go
+++ b/internal/comments/service_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/report/builder_test.go
+++ b/internal/report/builder_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/report"
+    "github.com/agynio/gh-pr-review/internal/report"
 )
 
 func TestBuildReportAggregatesThreads(t *testing.T) {

--- a/internal/report/builder_test.go
+++ b/internal/report/builder_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-    "github.com/agynio/gh-pr-review/internal/report"
+	"github.com/agynio/gh-pr-review/internal/report"
 )
 
 func TestBuildReportAggregatesThreads(t *testing.T) {

--- a/internal/report/service.go
+++ b/internal/report/service.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/ghcli"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 const (

--- a/internal/report/service.go
+++ b/internal/report/service.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-    "github.com/agynio/gh-pr-review/internal/ghcli"
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 const (

--- a/internal/report/service_test.go
+++ b/internal/report/service_test.go
@@ -7,7 +7,7 @@ import (
 
 	_ "embed"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 //go:embed testdata/report_response.json

--- a/internal/report/service_test.go
+++ b/internal/report/service_test.go
@@ -7,7 +7,7 @@ import (
 
 	_ "embed"
 
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 //go:embed testdata/report_response.json

--- a/internal/review/latest.go
+++ b/internal/review/latest.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 // LatestOptions configures lookup of the latest submitted review for a reviewer.

--- a/internal/review/latest.go
+++ b/internal/review/latest.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 // LatestOptions configures lookup of the latest submitted review for a reviewer.

--- a/internal/review/latest_test.go
+++ b/internal/review/latest_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/review/latest_test.go
+++ b/internal/review/latest_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/review/pending.go
+++ b/internal/review/pending.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 // PendingOptions configures lookup of the latest pending review for a reviewer.

--- a/internal/review/pending.go
+++ b/internal/review/pending.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 // PendingOptions configures lookup of the latest pending review for a reviewer.

--- a/internal/review/pending_test.go
+++ b/internal/review/pending_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/review/pending_test.go
+++ b/internal/review/pending_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/ghcli"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 // Service coordinates review GraphQL operations through the gh CLI.

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-    "github.com/agynio/gh-pr-review/internal/ghcli"
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 // Service coordinates review GraphQL operations through the gh CLI.

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-    "github.com/agynio/gh-pr-review/internal/ghcli"
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/ghcli"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-    "github.com/agynio/gh-pr-review/internal/ghcli"
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 // Service exposes pull request review thread operations.

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/ghcli"
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/ghcli"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 )
 
 // Service exposes pull request review thread operations.

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-    "github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Agyn-sandbox/gh-pr-review/internal/resolver"
+    "github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/Agyn-sandbox/gh-pr-review/cmd"
+import "github.com/agynio/gh-pr-review/cmd"
 
 func main() {
 	cmd.ExecuteOrExit()


### PR DESCRIPTION
## Summary
- switch the module path to `github.com/agynio/gh-pr-review` and update all internal imports
- refresh README installation instructions to reference `agynio/gh-pr-review`
- tidy modules after the rename

## Testing
- CGO_ENABLED=0 go build ./...
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 golangci-lint run

Resolves #4
