### PR TITLE
feat: add watch command for monitoring PR comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 bin/
 *.log
 .DS_Store
+gh-pr-review

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Designed for developers, DevOps teams, and AI systems that need **full pull requ
 **Blog post:** [gh-pr-review: LLM-friendly PR review workflows in your CLI](https://agyn.io/blog/gh-pr-review-cli-agent-workflows) — explains the motivation, design principles, and CLI + JSON output examples.  
 
 - [Quickstart](#quickstart)
+- [Watch for comments](#watch-for-comments)
 - [Review view](#review-view)
 - [Backend policy](#backend-policy)
 - [Additional docs](#additional-docs)
@@ -156,14 +157,68 @@ The quickest path from opening a pending review to resolving threads:
    ]
    ```
 
-   ```sh
-   gh pr-review threads resolve --thread-id R_ywDoABC123 -R owner/repo 42
-   
-   {
-     "thread_node_id": "R_ywDoABC123",
-     "is_resolved": true
-   }
-   ```
+    ```sh
+    gh pr-review threads resolve --thread-id R_ywDoABC123 -R owner/repo 42
+    
+    {
+      "thread_node_id": "R_ywDoABC123",
+      "is_resolved": true
+    }
+    ```
+
+## Watch for comments
+
+`gh pr-review watch` monitors a pull request for new comments and exits when
+they arrive. This is useful for automation workflows that need to wait for
+human feedback before proceeding.
+
+```sh
+gh pr-review watch -R owner/repo 42
+```
+
+The command polls for new review comments and issue comments at a configurable
+interval (default 10s). When new comments are detected, it debounces for 5
+seconds to collect any additional comments that arrive in quick succession
+(e.g., from a batch of commits being reviewed together).
+
+### Options
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `-i, --interval` | 10 | Polling interval in seconds |
+| `--debounce` | 5 | Debounce duration in seconds |
+| `--timeout` | 3600 | Maximum watch duration in seconds (1 hour) |
+| `--issue-comments` | true | Include issue comments (not just review comments) |
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | New comments found |
+| 1 | Error occurred |
+| 2 | Timed out with no new comments |
+
+### Example output
+
+```json
+{
+  "comments": [
+    {
+      "id": "review-123456789",
+      "node_id": "PRRC_kwDOAAABbhi7890",
+      "body": "Please add tests for this edge case",
+      "author_login": "reviewer",
+      "created_at": "2025-01-12T10:30:00Z",
+      "path": "internal/service.go",
+      "line": 42,
+      "type": "review",
+      "thread_id": "PRRT_kwDOAAABbFg12345"
+    }
+  ],
+  "timed_out": false,
+  "watched_ms": 15234
+}
+```
 
 ## Review view
 
@@ -282,6 +337,7 @@ Each command binds to a single GitHub backend—there are no runtime fallbacks.
 | `comments reply` | GraphQL | Replies via `addPullRequestReviewThreadReply`; supply `--review-id` when responding from a pending review. |
 | `threads list` | GraphQL | Enumerates review threads for the pull request. |
 | `threads resolve` / `unresolve` | GraphQL | Mutates thread resolution via `resolveReviewThread` / `unresolveReviewThread`; supply GraphQL thread node IDs (`PRRT_…`). |
+| `watch` | GraphQL | Polls for new comments via `reviewThreads` and `comments` queries; exits when new comments arrive or timeout is reached. |
 
 
 ## Additional docs

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ func newRootCommand() *cobra.Command {
 	cmd.AddCommand(newCommentsCommand())
 	cmd.AddCommand(newReviewCommand())
 	cmd.AddCommand(newThreadsCommand())
+	cmd.AddCommand(newWatchCommand())
 
 	return cmd
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/agynio/gh-pr-review/internal/resolver"
+	"github.com/agynio/gh-pr-review/internal/watch"
+)
+
+func newWatchCommand() *cobra.Command {
+	opts := &watchOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "watch [<number> | <url>]",
+		Short: "Watch for new PR comments and exit when they arrive",
+		Long: `Watch for new review comments or issue comments on a pull request.
+
+The command polls for new comments at a configurable interval (default 10s).
+When new comments are detected, it debounces for 5 seconds to collect any
+additional comments that arrive in quick succession (e.g., from a batch of
+commits being reviewed together).
+
+After the debounce period with no new comments, or when the timeout is reached,
+the command exits and outputs all new comments as JSON.
+
+Exit codes:
+  0  New comments found
+  1  Error occurred  
+  2  Timed out with no new comments`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Selector = args[0]
+			}
+			return runWatch(cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
+	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().IntVarP(&opts.Interval, "interval", "i", 10, "Polling interval in seconds")
+	cmd.Flags().IntVar(&opts.Debounce, "debounce", 5, "Debounce duration in seconds")
+	cmd.Flags().IntVar(&opts.Timeout, "timeout", 3600, "Maximum watch duration in seconds (default 1 hour)")
+	cmd.Flags().BoolVar(&opts.IncludeIssue, "issue-comments", true, "Include issue comments (not just review comments)")
+
+	return cmd
+}
+
+type watchOptions struct {
+	Repo         string
+	Pull         int
+	Selector     string
+	Interval     int
+	Debounce     int
+	Timeout      int
+	IncludeIssue bool
+}
+
+func runWatch(cmd *cobra.Command, opts *watchOptions) error {
+	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
+	if err != nil {
+		return err
+	}
+
+	hostEnv := os.Getenv("GH_HOST")
+	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
+	if err != nil {
+		return err
+	}
+
+	service := watch.NewService(apiClientFactory(identity.Host))
+
+	watchOpts := watch.WatchOptions{
+		Interval:     time.Duration(opts.Interval) * time.Second,
+		Debounce:     time.Duration(opts.Debounce) * time.Second,
+		Timeout:      time.Duration(opts.Timeout) * time.Second,
+		IncludeIssue: opts.IncludeIssue,
+	}
+
+	// Set up signal handling for graceful exit
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	fmt.Fprintf(os.Stderr, "Watching %s/%s#%d for new comments (interval=%ds, debounce=%ds, timeout=%ds)...\n",
+		identity.Owner, identity.Repo, identity.Number,
+		opts.Interval, opts.Debounce, opts.Timeout)
+
+	result, err := service.Watch(ctx, identity, watchOpts)
+	if err != nil {
+		return err
+	}
+
+	if err := encodeJSON(cmd, result); err != nil {
+		return err
+	}
+
+	// Exit with code 2 if timed out with no comments
+	if result.TimedOut && len(result.Comments) == 0 {
+		os.Exit(2)
+	}
+
+	return nil
+}

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -273,3 +273,86 @@ Returned by `threads resolve` and `threads unresolve`.
   "additionalProperties": false
 }
 ```
+
+## WatchResult
+
+Returned by `watch`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "WatchResult",
+  "type": "object",
+  "required": ["comments", "timed_out", "watched_ms"],
+  "properties": {
+    "comments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WatchComment"
+      }
+    },
+    "timed_out": {
+      "type": "boolean",
+      "description": "True if the watch ended due to timeout rather than new comments"
+    },
+    "watched_ms": {
+      "type": "integer",
+      "description": "Total watch duration in milliseconds"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "WatchComment": {
+      "type": "object",
+      "required": ["id", "body", "author_login", "created_at", "type"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier (prefixed with 'review-' or 'issue-')"
+        },
+        "node_id": {
+          "type": "string",
+          "description": "GraphQL comment node identifier"
+        },
+        "body": {
+          "type": "string"
+        },
+        "author_login": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "path": {
+          "type": "string",
+          "description": "File path (review comments only)"
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Line number (review comments only)"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["review", "issue"],
+          "description": "Comment type: 'review' for inline code comments, 'issue' for PR-level comments"
+        },
+        "thread_id": {
+          "type": "string",
+          "description": "GraphQL thread identifier (review comments only)"
+        },
+        "html_url": {
+          "type": "string",
+          "description": "URL to the comment on GitHub"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+```

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -283,7 +283,7 @@ Returned by `watch`.
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "WatchResult",
   "type": "object",
-  "required": ["comments", "timed_out", "watched_ms"],
+  "required": ["comments", "timed_out", "cancelled", "watched_ms"],
   "properties": {
     "comments": {
       "type": "array",
@@ -293,7 +293,11 @@ Returned by `watch`.
     },
     "timed_out": {
       "type": "boolean",
-      "description": "True if the watch ended due to timeout rather than new comments"
+      "description": "True if the watch ended due to timeout"
+    },
+    "cancelled": {
+      "type": "boolean",
+      "description": "True if the watch was cancelled by user interrupt (Ctrl+C)"
     },
     "watched_ms": {
       "type": "integer",

--- a/internal/watch/service.go
+++ b/internal/watch/service.go
@@ -1,0 +1,341 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/resolver"
+)
+
+// Service provides PR comment watching operations.
+type Service struct {
+	API ghcli.API
+}
+
+// NewService constructs a watch Service.
+func NewService(api ghcli.API) *Service {
+	return &Service{API: api}
+}
+
+// WatchOptions configures the watch behavior.
+type WatchOptions struct {
+	Interval      time.Duration // polling interval (default 10s)
+	Debounce      time.Duration // debounce duration (default 5s)
+	Timeout       time.Duration // max watch duration (default 1h)
+	IncludeIssue  bool          // include issue comments (not just review comments)
+}
+
+// Comment represents a PR comment (review or issue).
+type Comment struct {
+	ID          string  `json:"id"`
+	NodeID      string  `json:"node_id,omitempty"`
+	Body        string  `json:"body"`
+	AuthorLogin string  `json:"author_login"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at,omitempty"`
+	Path        *string `json:"path,omitempty"`
+	Line        *int    `json:"line,omitempty"`
+	Type        string  `json:"type"`
+	ThreadID    *string `json:"thread_id,omitempty"`
+	HTMLURL     string  `json:"html_url,omitempty"`
+}
+
+// WatchResult contains the watch outcome.
+type WatchResult struct {
+	Comments  []Comment `json:"comments"`
+	TimedOut  bool      `json:"timed_out"`
+	WatchedMs int64     `json:"watched_ms"`
+}
+
+// Watch polls for new comments on a PR and returns when new comments arrive (with debouncing).
+func (s *Service) Watch(ctx context.Context, pr resolver.Identity, opts WatchOptions) (*WatchResult, error) {
+	if opts.Interval <= 0 {
+		opts.Interval = 10 * time.Second
+	}
+	if opts.Debounce <= 0 {
+		opts.Debounce = 5 * time.Second
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = time.Hour
+	}
+
+	startTime := time.Now()
+	timeoutCtx, cancel := context.WithTimeout(ctx, opts.Timeout)
+	defer cancel()
+
+	// Get initial state of comments
+	knownIDs, err := s.fetchAllCommentIDs(pr, opts.IncludeIssue)
+	if err != nil {
+		return nil, fmt.Errorf("fetch initial comments: %w", err)
+	}
+
+	var (
+		newComments     []Comment
+		debounceTimer   *time.Timer
+		debounceStarted bool
+	)
+
+	ticker := time.NewTicker(opts.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			if debounceStarted && len(newComments) > 0 {
+				return &WatchResult{
+					Comments:  newComments,
+					TimedOut:  true,
+					WatchedMs: time.Since(startTime).Milliseconds(),
+				}, nil
+			}
+			return &WatchResult{
+				Comments:  nil,
+				TimedOut:  true,
+				WatchedMs: time.Since(startTime).Milliseconds(),
+			}, nil
+
+		case <-ticker.C:
+			currentComments, err := s.fetchAllComments(pr, opts.IncludeIssue)
+			if err != nil {
+				continue // ignore transient errors, keep polling
+			}
+
+			for _, c := range currentComments {
+				if _, seen := knownIDs[c.ID]; !seen {
+					knownIDs[c.ID] = struct{}{}
+					newComments = append(newComments, c)
+
+					// Start or reset debounce timer
+					if debounceTimer != nil {
+						debounceTimer.Stop()
+					}
+					debounceTimer = time.NewTimer(opts.Debounce)
+					debounceStarted = true
+				}
+			}
+
+		case <-func() <-chan time.Time {
+			if debounceTimer != nil {
+				return debounceTimer.C
+			}
+			return nil
+		}():
+			// Debounce timer fired - return collected comments
+			return &WatchResult{
+				Comments:  newComments,
+				TimedOut:  false,
+				WatchedMs: time.Since(startTime).Milliseconds(),
+			}, nil
+		}
+	}
+}
+
+func (s *Service) fetchAllCommentIDs(pr resolver.Identity, includeIssue bool) (map[string]struct{}, error) {
+	comments, err := s.fetchAllComments(pr, includeIssue)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make(map[string]struct{}, len(comments))
+	for _, c := range comments {
+		ids[c.ID] = struct{}{}
+	}
+	return ids, nil
+}
+
+func (s *Service) fetchAllComments(pr resolver.Identity, includeIssue bool) ([]Comment, error) {
+	var allComments []Comment
+
+	// Fetch review comments via GraphQL
+	reviewComments, err := s.fetchReviewComments(pr)
+	if err != nil {
+		return nil, fmt.Errorf("fetch review comments: %w", err)
+	}
+	allComments = append(allComments, reviewComments...)
+
+	// Optionally fetch issue comments
+	if includeIssue {
+		issueComments, err := s.fetchIssueComments(pr)
+		if err != nil {
+			return nil, fmt.Errorf("fetch issue comments: %w", err)
+		}
+		allComments = append(allComments, issueComments...)
+	}
+
+	return allComments, nil
+}
+
+func (s *Service) fetchReviewComments(pr resolver.Identity) ([]Comment, error) {
+	const query = `query ReviewComments($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          path
+          line
+          comments(first: 100) {
+            nodes {
+              id
+              databaseId
+              body
+              createdAt
+              updatedAt
+              url
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+	variables := map[string]interface{}{
+		"owner":  pr.Owner,
+		"name":   pr.Repo,
+		"number": pr.Number,
+	}
+
+	var response struct {
+		Repository *struct {
+			PullRequest *struct {
+				ReviewThreads struct {
+					Nodes []struct {
+						ID       string  `json:"id"`
+						Path     string  `json:"path"`
+						Line     *int    `json:"line"`
+						Comments struct {
+							Nodes []struct {
+								ID         string `json:"id"`
+								DatabaseID int    `json:"databaseId"`
+								Body       string `json:"body"`
+								CreatedAt  string `json:"createdAt"`
+								UpdatedAt  string `json:"updatedAt"`
+								URL        string `json:"url"`
+								Author     *struct {
+									Login string `json:"login"`
+								} `json:"author"`
+							} `json:"nodes"`
+						} `json:"comments"`
+					} `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	}
+
+	if err := s.API.GraphQL(query, variables, &response); err != nil {
+		return nil, err
+	}
+
+	if response.Repository == nil || response.Repository.PullRequest == nil {
+		return nil, fmt.Errorf("pull request %d not found on %s/%s", pr.Number, pr.Owner, pr.Repo)
+	}
+
+	var comments []Comment
+	for _, thread := range response.Repository.PullRequest.ReviewThreads.Nodes {
+		threadID := thread.ID
+		path := thread.Path
+		line := thread.Line
+
+		for _, c := range thread.Comments.Nodes {
+			authorLogin := ""
+			if c.Author != nil {
+				authorLogin = c.Author.Login
+			}
+
+			comments = append(comments, Comment{
+				ID:          fmt.Sprintf("review-%d", c.DatabaseID),
+				NodeID:      c.ID,
+				Body:        c.Body,
+				AuthorLogin: authorLogin,
+				CreatedAt:   c.CreatedAt,
+				UpdatedAt:   c.UpdatedAt,
+				Path:        &path,
+				Line:        line,
+				Type:        "review",
+				ThreadID:    &threadID,
+				HTMLURL:     c.URL,
+			})
+		}
+	}
+
+	return comments, nil
+}
+
+func (s *Service) fetchIssueComments(pr resolver.Identity) ([]Comment, error) {
+	const query = `query IssueComments($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      comments(first: 100) {
+        nodes {
+          id
+          databaseId
+          body
+          createdAt
+          updatedAt
+          url
+          author { login }
+        }
+      }
+    }
+  }
+}`
+
+	variables := map[string]interface{}{
+		"owner":  pr.Owner,
+		"name":   pr.Repo,
+		"number": pr.Number,
+	}
+
+	var response struct {
+		Repository *struct {
+			PullRequest *struct {
+				Comments struct {
+					Nodes []struct {
+						ID         string `json:"id"`
+						DatabaseID int    `json:"databaseId"`
+						Body       string `json:"body"`
+						CreatedAt  string `json:"createdAt"`
+						UpdatedAt  string `json:"updatedAt"`
+						URL        string `json:"url"`
+						Author     *struct {
+							Login string `json:"login"`
+						} `json:"author"`
+					} `json:"nodes"`
+				} `json:"comments"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	}
+
+	if err := s.API.GraphQL(query, variables, &response); err != nil {
+		return nil, err
+	}
+
+	if response.Repository == nil || response.Repository.PullRequest == nil {
+		return nil, fmt.Errorf("pull request %d not found on %s/%s", pr.Number, pr.Owner, pr.Repo)
+	}
+
+	var comments []Comment
+	for _, c := range response.Repository.PullRequest.Comments.Nodes {
+		authorLogin := ""
+		if c.Author != nil {
+			authorLogin = c.Author.Login
+		}
+
+		comments = append(comments, Comment{
+			ID:          fmt.Sprintf("issue-%d", c.DatabaseID),
+			NodeID:      c.ID,
+			Body:        c.Body,
+			AuthorLogin: authorLogin,
+			CreatedAt:   c.CreatedAt,
+			UpdatedAt:   c.UpdatedAt,
+			Type:        "issue",
+			HTMLURL:     c.URL,
+		})
+	}
+
+	return comments, nil
+}


### PR DESCRIPTION
Adds new `watch` command that polls for new review and issue comments on a pull request. Debounces by 5 seconds (configurable) to collect comments arriving in quick succession. Max timeout of 1 hour (configurable) after which it exits with code 2.

```sh
gh pr-review watch -R owner/repo 42
gh pr-review watch -R owner/repo 42 --interval 5 --debounce 3 --timeout 600
```

Exit codes: 0 (new comments), 1 (error), 2 (timeout with no comments)