### PR TITLE
feat(review): add --delete-comment flag for pending review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ The quickest path from opening a pending review to resolving threads:
    }
    ```
 
+   **Delete comments before submission (optional).** Use `--delete-comment` with
+   a comment node ID (`PRRC_…`) to remove a comment from a pending review:
+
+   ```sh
+   gh pr-review review --delete-comment \
+     --comment-id PRRC_kwDOAAABbcdEFG12 \
+     -R owner/repo 42
+
+   {
+     "status": "Comment deleted successfully"
+   }
+   ```
+
 4. **Inspect review threads (GraphQL).** `review view` surfaces pending
    review summaries, thread state, and inline comment metadata. Thread IDs are
    always included; enable `--include-comment-node-id` when you also need the
@@ -248,6 +261,7 @@ Each command binds to a single GitHub backend—there are no runtime fallbacks.
 | --- | --- | --- |
 | `review --start` | GraphQL | Opens a pending review via `addPullRequestReview`. |
 | `review --add-comment` | GraphQL | Requires a `PRR_…` review node ID. |
+| `review --delete-comment` | GraphQL | Deletes a comment from a pending review via `deletePullRequestReviewComment`; requires a `PRRC_…` comment node ID. |
 | `review view` | GraphQL | Aggregates reviews, inline comments, and replies (used for thread IDs). |
 | `review --submit` | GraphQL | Finalizes a pending review via `submitPullRequestReview` using the `PRR_…` review node ID (executed through the internal `gh api graphql` wrapper). |
 | `comments reply` | GraphQL | Replies via `addPullRequestReviewThreadReply`; supply `--review-id` when responding from a pending review. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when you need to:
 - Reply to review comments programmatically
 - Resolve or unresolve review threads
 - Create and submit PR reviews with inline comments
+- Delete comments from pending reviews
 - Access PR review context for automated workflows
 - Filter reviews by state, reviewer, or resolution status
 
@@ -93,6 +94,14 @@ gh pr-review review --add-comment \
   --path <file-path> \
   --line <line-number> \
   --body "Your comment" \
+  -R owner/repo <pr-number>
+```
+
+Delete a comment from pending review (requires comment node ID PRRC_...):
+
+```sh
+gh pr-review review --delete-comment \
+  --comment-id <PRRC_...> \
   -R owner/repo <pr-number>
 ```
 
@@ -175,7 +184,8 @@ gh pr-review review view --unresolved --not_outdated -R owner/repo --pr $(gh pr 
 
 1. Start: `gh pr-review review --start -R owner/repo <pr>`
 2. Add comments: `gh pr-review review --add-comment -R owner/repo <pr> --review-id <PRR_...> --path <file> --line <num> --body "..."`
-3. Submit: `gh pr-review review --submit -R owner/repo <pr> --review-id <PRR_...> --event REQUEST_CHANGES --body "Summary"`
+3. Delete comments (if needed): `gh pr-review review --delete-comment -R owner/repo <pr> --comment-id <PRRC_...>`
+4. Submit: `gh pr-review review --submit -R owner/repo <pr> --review-id <PRR_...> --event REQUEST_CHANGES --body "Summary"`
 
 ## Important Notes
 

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -32,10 +32,12 @@ func newReviewCommand() *cobra.Command {
 
 	cmd.Flags().BoolVar(&opts.Start, "start", false, "Open a pending review")
 	cmd.Flags().BoolVar(&opts.AddComment, "add-comment", false, "Add an inline comment to a pending review")
+	cmd.Flags().BoolVar(&opts.DeleteComment, "delete-comment", false, "Delete a comment from a pending review")
 	cmd.Flags().BoolVar(&opts.Submit, "submit", false, "Submit a pending review")
 
 	cmd.Flags().StringVar(&opts.Commit, "commit", "", "Commit SHA for review start (defaults to current head)")
 	cmd.Flags().StringVar(&opts.ReviewID, "review-id", "", "Review identifier (GraphQL review node ID)")
+	cmd.Flags().StringVar(&opts.CommentID, "comment-id", "", "Comment identifier (GraphQL comment node ID, PRRC_...)")
 	cmd.Flags().StringVar(&opts.Path, "path", "", "File path for inline comment")
 	cmd.Flags().IntVar(&opts.Line, "line", 0, "Line number for inline comment")
 	cmd.Flags().StringVar(&opts.Side, "side", opts.Side, "Diff side for inline comment (LEFT or RIGHT)")
@@ -54,12 +56,14 @@ type reviewOptions struct {
 	Pull     int
 	Selector string
 
-	Start      bool
-	AddComment bool
-	Submit     bool
+	Start         bool
+	AddComment    bool
+	DeleteComment bool
+	Submit        bool
 
 	Commit    string
 	ReviewID  string
+	CommentID string
 	Path      string
 	Line      int
 	Side      string
@@ -70,7 +74,7 @@ type reviewOptions struct {
 }
 
 func runReview(cmd *cobra.Command, opts *reviewOptions) error {
-	actions := []bool{opts.Start, opts.AddComment, opts.Submit}
+	actions := []bool{opts.Start, opts.AddComment, opts.DeleteComment, opts.Submit}
 	enabled := 0
 	for _, flag := range actions {
 		if flag {
@@ -78,7 +82,7 @@ func runReview(cmd *cobra.Command, opts *reviewOptions) error {
 		}
 	}
 	if enabled != 1 {
-		return errors.New("specify exactly one of --start, --add-comment, or --submit")
+		return errors.New("specify exactly one of --start, --add-comment, --delete-comment, or --submit")
 	}
 
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
@@ -99,6 +103,8 @@ func runReview(cmd *cobra.Command, opts *reviewOptions) error {
 		return executeReviewStart(cmd, service, identity, opts)
 	case opts.AddComment:
 		return executeReviewAddComment(cmd, service, identity, opts)
+	case opts.DeleteComment:
+		return executeReviewDeleteComment(cmd, service, identity, opts)
 	default: // Submit
 		return executeReviewSubmit(cmd, service, identity, opts)
 	}
@@ -153,6 +159,24 @@ func executeReviewAddComment(cmd *cobra.Command, service *reviewsvc.Service, pr 
 		return err
 	}
 	return encodeJSON(cmd, thread)
+}
+
+func executeReviewDeleteComment(cmd *cobra.Command, service *reviewsvc.Service, pr resolver.Identity, opts *reviewOptions) error {
+	commentID := strings.TrimSpace(opts.CommentID)
+	if commentID == "" {
+		return errors.New("--comment-id is required")
+	}
+	if !strings.HasPrefix(commentID, "PRRC_") {
+		return fmt.Errorf("invalid --comment-id %q: must be a GraphQL node id (PRRC_...)", opts.CommentID)
+	}
+
+	input := reviewsvc.DeleteCommentInput{
+		CommentID: commentID,
+	}
+	if err := service.DeleteComment(pr, input); err != nil {
+		return err
+	}
+	return encodeJSON(cmd, map[string]string{"status": "Comment deleted successfully"})
 }
 
 func executeReviewSubmit(cmd *cobra.Command, service *reviewsvc.Service, pr resolver.Identity, opts *reviewOptions) error {

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -222,6 +222,93 @@ func TestReviewSubmitCommandRejectsNonPRRPrefix(t *testing.T) {
 	assert.Contains(t, err.Error(), "GraphQL review node id")
 }
 
+func TestReviewDeleteCommentCommand_GraphQLOnly(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	fake := &commandFakeAPI{}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		input, ok := variables["input"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "PRRC_kwDOAAABbcdEFG12", input["id"])
+
+		return assignJSON(result, obj{
+			"data": obj{
+				"deletePullRequestReviewComment": obj{
+					"pullRequestReview": obj{"id": "PRR_review123"},
+				},
+			},
+		})
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{
+		"review", "--delete-comment",
+		"--comment-id", "PRRC_kwDOAAABbcdEFG12",
+		"--repo", "octo/demo", "7",
+	})
+
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String())
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, "Comment deleted successfully", payload["status"])
+}
+
+func TestReviewDeleteCommentCommandRequiresGraphQLCommentID(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	fake := &commandFakeAPI{}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		return errors.New("unexpected graphql invocation")
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"review", "--delete-comment",
+		"--comment-id", "12345",
+		"--repo", "octo/demo", "7",
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GraphQL node id")
+}
+
+func TestReviewDeleteCommentCommandRequiresCommentID(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	fake := &commandFakeAPI{}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		return errors.New("unexpected graphql invocation")
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"review", "--delete-comment",
+		"--repo", "octo/demo", "7",
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--comment-id is required")
+}
+
 func TestReviewSubmitCommandAllowsNullReview(t *testing.T) {
 	originalFactory := apiClientFactory
 	defer func() { apiClientFactory = originalFactory }()

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -57,6 +57,28 @@ gh pr-review review --add-comment \
 }
 ```
 
+## review --delete-comment (GraphQL only)
+
+- **Purpose:** Delete a comment from a pending review.
+- **Inputs:**
+  - `--comment-id` **(required):** GraphQL comment node ID (must start with
+    `PRRC_`).
+- **Backend:** GitHub GraphQL `deletePullRequestReviewComment` mutation.
+- **Output schema:** Status payload `{"status": "Comment deleted successfully"}`.
+
+```sh
+gh pr-review review --delete-comment \
+  --comment-id PRRC_kwDOAAABbcdEFG12 \
+  -R owner/repo 42
+
+{
+  "status": "Comment deleted successfully"
+}
+```
+
+> **Note:** This only works on comments in **pending** reviews. Once a review is
+> submitted, comments cannot be deleted via this API.
+
 ## review view (GraphQL only)
 
 - **Purpose:** Emit a consolidated snapshot of reviews, inline comments, and


### PR DESCRIPTION
## Summary

This PR implements the delete functionality for the CRUD lifecycle of pending review comments (fixes #13).

## Changes

### Code
- Added `--delete-comment` flag to delete a comment from a pending review
- Added `--comment-id` flag to specify the GraphQL comment node ID (PRRC_...)
- Validates that comment ID uses GraphQL node ID format
- Returns JSON status output following existing conventions

### Documentation
- Updated SKILL.md with delete-comment command and workflow
- Updated README.md quickstart with delete example
- Updated Backend policy table
- Added review --delete-comment section to docs/USAGE.md

### Tests
- Added `TestReviewDeleteCommentCommand_GraphQLOnly` - validates successful deletion with GraphQL mutation
- Added `TestReviewDeleteCommentCommandRequiresGraphQLCommentID` - validates PRRC_ prefix required
- Added `TestReviewDeleteCommentCommandRequiresCommentID` - validates --comment-id is required

## Usage

```sh
gh pr-review review --delete-comment \\
  --comment-id PRRC_kwDOAAABbcdEFG12 \\
  -R owner/repo 42
```

Expected output:
```json
{
  \"status\": \"Comment deleted successfully\"
}
```

## Manual Testing

✅ Tested on PR #15:
1. Created pending review: `gh pr-review review --start`
2. Added test comment: `gh pr-review review --add-comment`
3. Queried comment ID via GraphQL API
4. Deleted comment: `gh pr-review review --delete-comment --comment-id PRRC_...`
5. Verified comment was removed

## Implementation Details

- Uses GraphQL mutation `deletePullRequestReviewComment`
- Follows the same patterns as existing `--add-comment` and `--submit` commands
- Only works on pending review comments (GraphQL API restriction)

## Testing

All tests pass (including new tests):
```
CGO_ENABLED=0 go test ./...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)