### PR TITLE
Docs: update outdated skill installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,17 @@ Each command binds to a single GitHub backend—there are no runtime fallbacks.
 To add gh-pr-review as a skill to your AI coding agent:
 
 ```sh
-npx @vercel/add-skill https://github.com/agynio/gh-pr-review
+npx skills add agynio/gh-pr-review
+```
+
+Additional options:
+
+```sh
+# Install to a specific agent
+npx skills add agynio/gh-pr-review -a claude-code
+
+# Install globally (available across all projects)
+npx skills add agynio/gh-pr-review -g
 ```
 
 This command will:


### PR DESCRIPTION
## Summary

Replace the deprecated `@vercel/add-skill` package with the new `skills` CLI.

## Changes

**Before:**
```sh
npx @vercel/add-skill https://github.com/agynio/gh-pr-review
```

**After:**
```sh
npx skills add agynio/gh-pr-review
```

Also documents new CLI options:
- `-a claude-code` — install to a specific agent
- `-g` — install globally (available across all projects)

## Related Issue

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)