### PR TITLE
Infer owner/repo and PR number from git context

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,15 @@ The quickest path from opening a pending review to resolving threads:
 
 
 2. **Start a pending review (GraphQL).** Capture the returned `id` (GraphQL
-   node).
+   node). When run inside a git repository, `-R owner/repo` and the PR number
+   are inferred automatically from the git remote and current branch.
 
    ```sh
+   # Explicit (works anywhere)
    gh pr-review review --start -R owner/repo 42
+
+   # Inferred (inside a repo, on a branch with an open PR)
+   gh pr-review review --start
 
    {
      "id": "PRR_kwDOAAABbcdEFG12",
@@ -175,10 +180,15 @@ The quickest path from opening a pending review to resolving threads:
 discussion. The response groups reviews → parent inline comments → thread
 replies, omitting optional fields entirely instead of returning `null`.
 
-Run it with either a combined selector or explicit flags:
+Run it with either a combined selector or explicit flags. When inside a git
+repository, `-R` and `--pr` are inferred automatically:
 
 ```sh
+# Explicit
 gh pr-review review view -R owner/repo --pr 3
+
+# Inferred (inside the repo, on a branch with an open PR)
+gh pr-review review view
 ```
 
 Install or upgrade to **v1.6.0 or newer** (GraphQL-only thread resolution and minimal comment replies):
@@ -322,13 +332,13 @@ All commands return structured JSON optimized for agent consumption with minimal
 ### Example Agent Workflow
 
 ```
-User: "Show me unresolved comments on PR #42"
-Agent: gh pr-review review view -R owner/repo --pr 42 --unresolved --not_outdated
+User: "Show me unresolved comments on this PR"
+Agent: gh pr-review review view --unresolved --not_outdated
 Agent: [Parses JSON, summarizes 3 unresolved threads]
 
 User: "Reply to the comment about error handling"
-Agent: gh pr-review comments reply 42 -R owner/repo --thread-id PRRT_... --body "Fixed in commit abc123"
-Agent: gh pr-review threads resolve 42 -R owner/repo --thread-id PRRT_...
+Agent: gh pr-review comments reply --thread-id PRRT_... --body "Fixed in commit abc123"
+Agent: gh pr-review threads resolve --thread-id PRRT_...
 ```
 
 ### Skill Documentation

--- a/SKILL.md
+++ b/SKILL.md
@@ -32,6 +32,13 @@ First, ensure the extension is installed:
 gh extension install agynio/gh-pr-review
 ```
 
+## Repository and PR Inference
+
+When run inside a git repository, `-R owner/repo` and `--pr` / PR number are
+**inferred automatically** from the git remote and current branch. You only need
+to specify them explicitly when working outside a repo or targeting a different
+repo/PR.
+
 ## Core Commands
 
 ### 1. View All Reviews and Threads
@@ -39,7 +46,11 @@ gh extension install agynio/gh-pr-review
 Get complete review context with inline comments and thread replies:
 
 ```sh
+# Explicit
 gh pr-review review view -R owner/repo --pr <number>
+
+# Inferred (inside a repo, on a branch with an open PR)
+gh pr-review review view
 ```
 
 **Useful filters:**
@@ -150,32 +161,33 @@ Example output structure:
 
 ## Best Practices
 
-1. **Always use `-R owner/repo`** to specify the repository explicitly
-2. **Use `--unresolved` and `--not_outdated`** to focus on actionable comments
-3. **Save thread_id values** from `review view` output for replying
-4. **Filter by reviewer** when dealing with specific review feedback
-5. **Use `--tail 1`** to reduce output size by keeping only latest replies
-6. **Parse JSON output** instead of trying to scrape text
+1. **Rely on inference** when inside a git repo — `-R` and `--pr` are optional
+2. **Use `-R owner/repo`** explicitly when targeting a different repository
+3. **Use `--unresolved` and `--not_outdated`** to focus on actionable comments
+4. **Save thread_id values** from `review view` output for replying
+5. **Filter by reviewer** when dealing with specific review feedback
+6. **Use `--tail 1`** to reduce output size by keeping only latest replies
+7. **Parse JSON output** instead of trying to scrape text
 
 ## Common Workflows
 
 ### Get Unresolved Comments for Current PR
 
 ```sh
-gh pr-review review view --unresolved --not_outdated -R owner/repo --pr $(gh pr view --json number -q .number)
+gh pr-review review view --unresolved --not_outdated
 ```
 
 ### Reply to All Unresolved Comments
 
-1. Get unresolved threads: `gh pr-review threads list --unresolved -R owner/repo <pr>`
-2. For each thread_id, reply: `gh pr-review comments reply <pr> -R owner/repo --thread-id <id> --body "..."`
-3. Optionally resolve: `gh pr-review threads resolve <pr> -R owner/repo --thread-id <id>`
+1. Get unresolved threads: `gh pr-review threads list --unresolved`
+2. For each thread_id, reply: `gh pr-review comments reply --thread-id <id> --body "..."`
+3. Optionally resolve: `gh pr-review threads resolve --thread-id <id>`
 
 ### Create Review with Inline Comments
 
-1. Start: `gh pr-review review --start -R owner/repo <pr>`
-2. Add comments: `gh pr-review review --add-comment -R owner/repo <pr> --review-id <PRR_...> --path <file> --line <num> --body "..."`
-3. Submit: `gh pr-review review --submit -R owner/repo <pr> --review-id <PRR_...> --event REQUEST_CHANGES --body "Summary"`
+1. Start: `gh pr-review review --start`
+2. Add comments: `gh pr-review review --add-comment --review-id <PRR_...> --path <file> --line <num> --body "..."`
+3. Submit: `gh pr-review review --submit --review-id <PRR_...> --event REQUEST_CHANGES --body "Summary"`
 
 ## Important Notes
 

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -80,11 +80,13 @@ type commentsReplyOptions struct {
 }
 
 func runCommentsReply(cmd *cobra.Command, opts *commentsReplyOptions) error {
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	hostEnv := os.Getenv("GH_HOST")
 	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
 	if err != nil {

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -5,3 +5,21 @@ import "github.com/agynio/gh-pr-review/internal/ghcli"
 var apiClientFactory = func(host string) ghcli.API {
 	return &ghcli.Client{Host: host}
 }
+
+// inferRepo fills in repo from the current git context when not explicitly provided.
+func inferRepo(repo *string) {
+	if *repo == "" {
+		if r, err := ghcli.CurrentRepo(); err == nil {
+			*repo = r
+		}
+	}
+}
+
+// inferPR fills in the PR number from the current branch when not explicitly provided.
+func inferPR(selector string, pr *int) {
+	if selector == "" && *pr == 0 {
+		if n, err := ghcli.CurrentPR(); err == nil {
+			*pr = n
+		}
+	}
+}

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -81,11 +81,13 @@ func runReview(cmd *cobra.Command, opts *reviewOptions) error {
 		return errors.New("specify exactly one of --start, --add-comment, or --submit")
 	}
 
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	hostEnv := os.Getenv("GH_HOST")
 	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
 	if err != nil {

--- a/cmd/review_view.go
+++ b/cmd/review_view.go
@@ -56,6 +56,7 @@ func runReviewView(cmd *cobra.Command, opts *reviewViewOptions) error {
 		return fmt.Errorf("invalid --tail value %d: must be non-negative", opts.TailReplies)
 	}
 
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
@@ -66,6 +67,7 @@ func runReviewView(cmd *cobra.Command, opts *reviewViewOptions) error {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	identity, err := resolver.Resolve(selector, opts.Repo, os.Getenv("GH_HOST"))
 	if err != nil {
 		return err

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -56,11 +56,13 @@ type threadsListOptions struct {
 }
 
 func runThreadsList(cmd *cobra.Command, opts *threadsListOptions) error {
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	hostEnv := os.Getenv("GH_HOST")
 	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
 	if err != nil {
@@ -145,11 +147,13 @@ func runThreadsUnresolve(cmd *cobra.Command, opts *threadsMutationOptions) error
 }
 
 func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolve bool) error {
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	hostEnv := os.Getenv("GH_HOST")
 	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
 	if err != nil {

--- a/internal/ghcli/ghcli.go
+++ b/internal/ghcli/ghcli.go
@@ -210,6 +210,40 @@ func (c *Client) GraphQL(query string, variables map[string]interface{}, result 
 	return nil
 }
 
+// CurrentRepo returns the "owner/repo" for the current working directory
+// by delegating to `gh repo view`. This respects `gh repo set-default`
+// and the git remote configuration.
+func CurrentRepo() (string, error) {
+	stdout, stderr, err := runGh([]string{"repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"}, nil)
+	if err != nil {
+		return "", wrapError(err, stdout, stderr)
+	}
+	result := strings.TrimSpace(string(stdout))
+	if result == "" {
+		return "", fmt.Errorf("gh repo view returned empty nameWithOwner")
+	}
+	return result, nil
+}
+
+// CurrentPR returns the pull request number for the current branch
+// by delegating to `gh pr view`. Returns 0 and an error if the current
+// branch has no associated pull request.
+func CurrentPR() (int, error) {
+	stdout, stderr, err := runGh([]string{"pr", "view", "--json", "number", "-q", ".number"}, nil)
+	if err != nil {
+		return 0, wrapError(err, stdout, stderr)
+	}
+	result := strings.TrimSpace(string(stdout))
+	if result == "" {
+		return 0, fmt.Errorf("gh pr view returned empty number")
+	}
+	n, err := strconv.Atoi(result)
+	if err != nil {
+		return 0, fmt.Errorf("gh pr view returned non-numeric number: %q", result)
+	}
+	return n, nil
+}
+
 // runGh executes the `gh` CLI command with provided arguments and optional stdin data.
 func runGh(args []string, stdin []byte) ([]byte, string, error) {
 	cmd := exec.Command("gh", args...)


### PR DESCRIPTION
## Summary
- Automatically infer `--repo` (owner/repo) from the current git remote via `gh repo view`, respecting `gh repo set-default`
- Automatically infer `--pr` from the current branch's associated pull request via `gh pr view`
- Both flags remain fully functional when provided explicitly — inference only kicks in when they are omitted
- Updated README and SKILL.md to document the new behavior

Closes #19

## Test plan
- [x] `go build ./...` and `go test ./...` pass
- [x] Verified repo inference: `gh pr-review threads list --pr 15` works without `--repo`
- [x] Verified full inference: checked out PR #15's branch, ran `gh pr-review threads list` and `gh pr-review review view` with zero flags — both repo and PR inferred correctly
- [x] Verify outside a git repo: should get existing "missing --repo" error