### PR TITLE
feat: add --body-file flag to read body from file or stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ The quickest path from opening a pending review to resolving threads:
      --line 42 \
      --body "nit: use helper" \
      -R owner/repo 42
+   ```
+
+   You can also read the body from a file with `--body-file`:
+
+   ```sh
+   gh pr-review review --add-comment \
+     --review-id PRR_kwDOAAABbcdEFG12 \
+     --path internal/service.go \
+     --line 42 \
+     --body-file comment.md \
+     -R owner/repo 42
+   ```
+
+   Or pipe content directly from stdin:
+
+   ```sh
+   echo "nit: use helper" | gh pr-review review --add-comment \
+     --review-id PRR_kwDOAAABbcdEFG12 \
+     --path internal/service.go \
+     --line 42 \
+     --body-file - \
+     -R owner/repo 42
+   ```
 
    {
      "id": "PRRT_kwDOAAABbcdEFG12",
@@ -212,6 +235,10 @@ For the full canonical response structure, see docs/SCHEMAS.md.
 | `--not_outdated` | Exclude threads marked as outdated. |
 | `--tail <n>` | Retain only the last `n` replies per thread (0 = all). The parent inline comment is always kept; only replies are trimmed. |
 | `--include-comment-node-id` | Add GraphQL comment node identifiers to parent comments and replies. |
+
+Commands that accept `--body` also support `--body-file <path>` to read body
+text from a file. Use `--body-file -` to read from stdin. The two flags are
+mutually exclusive.
 
 ### Examples
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,6 +61,14 @@ gh pr-review comments reply <pr-number> -R owner/repo \
   --body "Your reply message"
 ```
 
+Alternatively, read the reply from a file (use `"-"` for stdin):
+
+```sh
+gh pr-review comments reply <pr-number> -R owner/repo \
+  --thread-id <PRRT_...> \
+  --body-file reply.md
+```
+
 ### 3. List Review Threads
 
 Get a filtered list of review threads:
@@ -93,6 +101,17 @@ gh pr-review review --add-comment \
   --path <file-path> \
   --line <line-number> \
   --body "Your comment" \
+  -R owner/repo <pr-number>
+```
+
+Or read the comment body from a file (use `"-"` for stdin):
+
+```sh
+gh pr-review review --add-comment \
+  --review-id <PRR_...> \
+  --path <file-path> \
+  --line <line-number> \
+  --body-file comment.md \
   -R owner/repo <pr-number>
 ```
 
@@ -174,7 +193,7 @@ gh pr-review review view --unresolved --not_outdated -R owner/repo --pr $(gh pr 
 ### Create Review with Inline Comments
 
 1. Start: `gh pr-review review --start -R owner/repo <pr>`
-2. Add comments: `gh pr-review review --add-comment -R owner/repo <pr> --review-id <PRR_...> --path <file> --line <num> --body "..."`
+2. Add comments: `gh pr-review review --add-comment -R owner/repo <pr> --review-id <PRR_...> --path <file> --line <num> --body "..."` (or use `--body-file <path>`)
 3. Submit: `gh pr-review review --submit -R owner/repo <pr> --review-id <PRR_...> --event REQUEST_CHANGES --body "Summary"`
 
 ## Important Notes

--- a/cmd/body.go
+++ b/cmd/body.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// resolveBody returns the body text from either the --body flag value or the
+// contents of the file specified by --body-file.  When bodyFile is "-", stdin
+// is read.  If both values are provided the caller has a configuration error;
+// mutual-exclusivity should be enforced by cobra flag groups, but this
+// function returns a defensive error as well.  When neither is provided an
+// empty string is returned — downstream validation decides whether that is
+// acceptable.
+func resolveBody(body, bodyFile string) (string, error) {
+	if body != "" && bodyFile != "" {
+		return "", fmt.Errorf("specify --body or --body-file, not both")
+	}
+	if bodyFile == "" {
+		return body, nil
+	}
+
+	var data []byte
+	var err error
+	if bodyFile == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(bodyFile) // #nosec G304 — user-supplied path is intentional
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to read body file: %w", err)
+	}
+	return string(data), nil
+}

--- a/cmd/body_test.go
+++ b/cmd/body_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveBody_OnlyBody(t *testing.T) {
+	got, err := resolveBody("hello", "")
+	require.NoError(t, err)
+	assert.Equal(t, "hello", got)
+}
+
+func TestResolveBody_NeitherSet(t *testing.T) {
+	got, err := resolveBody("", "")
+	require.NoError(t, err)
+	assert.Equal(t, "", got)
+}
+
+func TestResolveBody_BothSet(t *testing.T) {
+	_, err := resolveBody("hello", "file.txt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "specify --body or --body-file, not both")
+}
+
+func TestResolveBody_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "body.txt")
+	require.NoError(t, os.WriteFile(p, []byte("from file"), 0600))
+
+	got, err := resolveBody("", p)
+	require.NoError(t, err)
+	assert.Equal(t, "from file", got)
+}
+
+func TestResolveBody_FromFileNotFound(t *testing.T) {
+	_, err := resolveBody("", "/nonexistent/path/body.txt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read body file")
+}
+
+func TestResolveBody_FromStdin(t *testing.T) {
+	// Replace os.Stdin with a pipe containing test data.
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	_, err = w.WriteString("stdin content")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	got, err := resolveBody("", "-")
+	require.NoError(t, err)
+	assert.Equal(t, "stdin content", got)
+}

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -64,8 +64,9 @@ func newCommentsReplyCommand(parent *commentsOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.ThreadID, "thread-id", "", "Review thread identifier to reply to")
 	cmd.Flags().StringVar(&opts.ReviewID, "review-id", "", "GraphQL review identifier when replying inside a pending review")
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Reply text")
+	cmd.Flags().StringVar(&opts.BodyFile, "body-file", "", "Read reply text from file (use \"-\" for stdin)")
 	_ = cmd.MarkFlagRequired("thread-id")
-	_ = cmd.MarkFlagRequired("body")
+	cmd.MarkFlagsMutuallyExclusive("body", "body-file")
 
 	return cmd
 }
@@ -77,9 +78,19 @@ type commentsReplyOptions struct {
 	ThreadID string
 	ReviewID string
 	Body     string
+	BodyFile string
 }
 
 func runCommentsReply(cmd *cobra.Command, opts *commentsReplyOptions) error {
+	body, err := resolveBody(opts.Body, opts.BodyFile)
+	if err != nil {
+		return err
+	}
+	if body == "" {
+		return errors.New("--body or --body-file is required")
+	}
+	opts.Body = body
+
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err

--- a/cmd/comments_test.go
+++ b/cmd/comments_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -202,6 +203,104 @@ func TestCommentsReplyCommandWithoutReviewID(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	require.Len(t, payload, 1)
 	assert.Equal(t, "PRRC_reply", payload["comment_node_id"])
+}
+
+func TestCommentsReplyCommandWithBodyFile(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	dir := t.TempDir()
+	bodyPath := filepath.Join(dir, "body.txt")
+	require.NoError(t, os.WriteFile(bodyPath, []byte("from file"), 0600))
+
+	fake := &commandFakeAPI{}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		switch {
+		case strings.Contains(query, "AddPullRequestReviewThreadReply"):
+			input, ok := variables["input"].(map[string]interface{})
+			require.True(t, ok)
+			require.Equal(t, "from file", input["body"])
+
+			payload := map[string]interface{}{
+				"addPullRequestReviewThreadReply": map[string]interface{}{
+					"comment": map[string]interface{}{
+						"id":          "PRRC_reply",
+						"body":        "from file",
+						"publishedAt": "2025-12-03T10:00:00Z",
+						"author":      map[string]interface{}{"login": "octocat"},
+					},
+				},
+			}
+			return assignJSON(result, payload)
+		case strings.Contains(query, "PullRequestReviewCommentDetails"):
+			payload := map[string]interface{}{
+				"node": map[string]interface{}{
+					"id":                "PRRC_reply",
+					"databaseId":        nil,
+					"body":              "from file",
+					"diffHunk":          "",
+					"path":              "",
+					"url":               "https://example.com/comment",
+					"createdAt":         "2025-12-03T10:00:00Z",
+					"updatedAt":         "2025-12-03T10:05:00Z",
+					"author":            map[string]interface{}{"login": "octocat"},
+					"pullRequestReview": nil,
+					"replyTo":           nil,
+				},
+			}
+			return assignJSON(result, payload)
+		case strings.Contains(query, "PullRequestReviewThreadDetails"):
+			payload := map[string]interface{}{
+				"node": map[string]interface{}{
+					"id":         "PRRT_thread",
+					"isResolved": false,
+					"isOutdated": false,
+				},
+			}
+			return assignJSON(result, payload)
+		default:
+			t.Fatalf("unexpected query: %s", query)
+			return nil
+		}
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"comments", "reply", "--thread-id", "PRRT_thread", "--body-file", bodyPath, "--repo", "octo/demo", "7"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String())
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, "PRRC_reply", payload["comment_node_id"])
+}
+
+func TestCommentsReplyCommandBodyAndBodyFileMutuallyExclusive(t *testing.T) {
+	root := newRootCommand()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"comments", "reply", "--thread-id", "PRRT_thread", "--body", "text", "--body-file", "file.txt", "--repo", "octo/demo", "7"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "body")
+}
+
+func TestCommentsReplyCommandRequiresBodyOrBodyFile(t *testing.T) {
+	root := newRootCommand()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"comments", "reply", "--thread-id", "PRRT_thread", "--repo", "octo/demo", "7"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--body or --body-file is required")
 }
 
 func assignJSON(result interface{}, payload interface{}) error {

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -42,7 +42,9 @@ func newReviewCommand() *cobra.Command {
 	cmd.Flags().IntVar(&opts.StartLine, "start-line", 0, "Start line for multi-line comments")
 	cmd.Flags().StringVar(&opts.StartSide, "start-side", "", "Start side for multi-line comments")
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Comment or review body")
+	cmd.Flags().StringVar(&opts.BodyFile, "body-file", "", "Read body from file (use \"-\" for stdin)")
 	cmd.Flags().StringVar(&opts.Event, "event", opts.Event, "Review submission event (APPROVE, COMMENT, REQUEST_CHANGES)")
+	cmd.MarkFlagsMutuallyExclusive("body", "body-file")
 
 	cmd.AddCommand(newReviewViewCommand())
 
@@ -66,6 +68,7 @@ type reviewOptions struct {
 	StartLine int
 	StartSide string
 	Body      string
+	BodyFile  string
 	Event     string
 }
 
@@ -80,6 +83,12 @@ func runReview(cmd *cobra.Command, opts *reviewOptions) error {
 	if enabled != 1 {
 		return errors.New("specify exactly one of --start, --add-comment, or --submit")
 	}
+
+	body, err := resolveBody(opts.Body, opts.BodyFile)
+	if err != nil {
+		return err
+	}
+	opts.Body = body
 
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/agynio/gh-pr-review/internal/ghcli"
@@ -280,4 +282,99 @@ func TestReviewSubmitCommandHandlesGraphQLErrors(t *testing.T) {
 	first, ok := errorsField[0].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "mutation failed", first["message"])
+}
+
+func TestReviewAddCommentCommandWithBodyFile(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	dir := t.TempDir()
+	bodyPath := filepath.Join(dir, "body.txt")
+	require.NoError(t, os.WriteFile(bodyPath, []byte("file note"), 0600))
+
+	fake := &commandFakeAPI{}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		input, ok := variables["input"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "file note", input["body"])
+
+		payload := map[string]interface{}{
+			"addPullRequestReviewThread": map[string]interface{}{
+				"thread": map[string]interface{}{
+					"id":         "THREAD1",
+					"path":       "scenario.md",
+					"isOutdated": false,
+					"line":       12,
+				},
+			},
+		}
+		return assignJSON(result, payload)
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"review", "--add-comment", "--review-id", "PRR_review", "--path", "scenario.md", "--line", "12", "--body-file", bodyPath, "--repo", "octo/demo", "7"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String())
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, "THREAD1", payload["id"])
+}
+
+func TestReviewSubmitCommandWithBodyFile(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	dir := t.TempDir()
+	bodyPath := filepath.Join(dir, "body.txt")
+	require.NoError(t, os.WriteFile(bodyPath, []byte("Please update"), 0600))
+
+	fake := &commandFakeAPI{}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		payload, ok := variables["input"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "Please update", payload["body"])
+
+		return assignJSON(result, obj{
+			"data": obj{
+				"submitPullRequestReview": obj{
+					"pullRequestReview": obj{"id": "PRR_kwM123"},
+				},
+			},
+		})
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"review", "--submit", "--review-id", "PRR_kwM123", "--event", "COMMENT", "--body-file", bodyPath, "--repo", "octo/demo", "7"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String())
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, "Review submitted successfully", payload["status"])
+}
+
+func TestReviewBodyAndBodyFileMutuallyExclusive(t *testing.T) {
+	root := newRootCommand()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"review", "--add-comment", "--review-id", "PRR_review", "--path", "f.go", "--line", "1", "--body", "text", "--body-file", "file.txt", "--repo", "octo/demo", "7"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "body")
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -36,6 +36,8 @@ gh pr-review review --start -R owner/repo 42
   - `--review-id` **(required):** GraphQL review node ID (must start with
     `PRR_`). Numeric IDs are rejected.
   - `--path`, `--line`, `--body` **(required).**
+  - `--body-file`: Read body from a file instead of `--body` (use `"-"` for
+    stdin). Mutually exclusive with `--body`.
   - `--side`, `--start-line`, `--start-side` to describe diff positioning.
 - **Backend:** GitHub GraphQL `addPullRequestReviewThread` mutation.
 - **Output schema:** [`ReviewThread`](SCHEMAS.md#reviewthread) — required fields
@@ -114,6 +116,8 @@ omitted otherwise.
   - `--event` **(required):** One of `COMMENT`, `APPROVE`, `REQUEST_CHANGES`.
   - `--body`: Optional message. GitHub requires a body for
     `REQUEST_CHANGES`.
+  - `--body-file`: Read body from a file instead of `--body` (use `"-"` for
+    stdin). Mutually exclusive with `--body`.
 - **Backend:** GitHub GraphQL `submitPullRequestReview` mutation.
 - **Output schema:** Status payload `{"status": "…"}`. When GraphQL returns
   errors, the command emits `{ "status": "Review submission failed",
@@ -151,7 +155,9 @@ gh pr-review review --submit \
   - `--thread-id` **(required):** GraphQL review thread identifier (`PRRT_…`).
   - `--review-id`: GraphQL review identifier when replying inside your pending
     review (`PRR_…`).
-  - `--body` **(required).**
+  - `--body` **(required,** or use `--body-file`**).**
+  - `--body-file`: Read reply text from a file instead of `--body` (use `"-"`
+    for stdin). Mutually exclusive with `--body`.
 - **Backend:** GitHub GraphQL `addPullRequestReviewThreadReply` mutation.
 - **Output schema:** [`ReplyMinimal`](SCHEMAS.md#replyminimal).
 


### PR DESCRIPTION
## Add `--body-file` flag for reading body text from files or stdin

### Problem

Review comments and reply bodies are currently limited to the `--body` flag, which means the entire text must be passed as a command-line argument. This creates friction for several real-world workflows:

- **Multi-line or formatted comments** (e.g., Markdown tables, code snippets) are awkward to escape and quote on the command line
- **Agent and CI pipelines** that generate review text dynamically must serialize content into a shell-safe string before passing it
- **Composing longer review summaries** in an editor is not supported — you cannot write to a file and reference it

### Solution

Commands that accept `--body` now also accept `--body-file <path>`, following the same convention used by `gh pr create --body-file`. Passing `--body-file -` reads from stdin, enabling piped workflows:

```sh
# Read from a file
gh pr-review comments reply 42 -R owner/repo \
  --thread-id PRRT_... --body-file reply.md

# Pipe from another command
generate-review-comment | gh pr-review review --add-comment \
  --review-id PRR_... --path src/app.go --line 10 \
  --body-file - -R owner/repo 42