### PR TITLE
feat: agent triage workflow — reactions, author filter, commit-linked resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,15 @@ The quickest path from opening a pending review to resolving threads:
 
 
 2. **Start a pending review (GraphQL).** Capture the returned `id` (GraphQL
-   node).
+   node). When run inside a git repository, `-R owner/repo` and the PR number
+   are inferred automatically from the git remote and current branch.
 
    ```sh
+   # Explicit (works anywhere)
    gh pr-review review --start -R owner/repo 42
+
+   # Inferred (inside a repo, on a branch with an open PR)
+   gh pr-review review --start
 
    {
      "id": "PRR_kwDOAAABbcdEFG12",
@@ -175,10 +180,15 @@ The quickest path from opening a pending review to resolving threads:
 discussion. The response groups reviews → parent inline comments → thread
 replies, omitting optional fields entirely instead of returning `null`.
 
-Run it with either a combined selector or explicit flags:
+Run it with either a combined selector or explicit flags. When inside a git
+repository, `-R` and `--pr` are inferred automatically:
 
 ```sh
+# Explicit
 gh pr-review review view -R owner/repo --pr 3
+
+# Inferred (inside the repo, on a branch with an open PR)
+gh pr-review review view
 ```
 
 Install or upgrade to **v1.6.0 or newer** (GraphQL-only thread resolution and minimal comment replies):
@@ -322,13 +332,13 @@ All commands return structured JSON optimized for agent consumption with minimal
 ### Example Agent Workflow
 
 ```
-User: "Show me unresolved comments on PR #42"
-Agent: gh pr-review review view -R owner/repo --pr 42 --unresolved --not_outdated
+User: "Show me unresolved comments on this PR"
+Agent: gh pr-review review view --unresolved --not_outdated
 Agent: [Parses JSON, summarizes 3 unresolved threads]
 
 User: "Reply to the comment about error handling"
-Agent: gh pr-review comments reply 42 -R owner/repo --thread-id PRRT_... --body "Fixed in commit abc123"
-Agent: gh pr-review threads resolve 42 -R owner/repo --thread-id PRRT_...
+Agent: gh pr-review comments reply --thread-id PRRT_... --body "Fixed in commit abc123"
+Agent: gh pr-review threads resolve --thread-id PRRT_...
 ```
 
 ### Skill Documentation

--- a/README.md
+++ b/README.md
@@ -1,197 +1,44 @@
 # gh-pr-review
 [![Agyn badge](https://agyn.io/badges/badge_dark.svg)](http://agyn.io)
 
-`gh-pr-review` is a GitHub CLI extension that finally brings **inline PR review comments** to the terminal.  
-GitHub’s built-in `gh` tool does *not* show inline comments or review threads — but this extension does.
+`gh-pr-review` is a GitHub CLI extension that brings **inline PR review threads** to the terminal — with filtering, bulk resolution, and structured JSON output designed for agents.
 
-With `gh-pr-review`, you can:
+GitHub's built-in `gh` tool does *not* expose inline review threads or let you resolve them programmatically. This extension does, and it goes further: it was built under real agent-scale load — 178 review threads across CodeRabbit, Codex, and human reviewers on a single PR — and every flag was added to solve a real triage problem.
 
-- View complete **inline review threads** with file and line context  
-- See **unresolved comments** during code review  
-- Reply to inline comments directly from the terminal  
-- Resolve review threads programmatically  
-- Export structured output ideal for **LLMs and automated PR review agents**
+**Blog post:** [gh-pr-review: LLM-friendly PR review workflows in your CLI](https://agyn.io/blog/gh-pr-review-cli-agent-workflows)
 
-Designed for developers, DevOps teams, and AI systems that need **full pull request review context**, not just top-level comments.
-
-**Blog post:** [gh-pr-review: LLM-friendly PR review workflows in your CLI](https://agyn.io/blog/gh-pr-review-cli-agent-workflows) — explains the motivation, design principles, and CLI + JSON output examples.  
+---
 
 - [Quickstart](#quickstart)
-- [Review view](#review-view)
-- [Backend policy](#backend-policy)
-- [Additional docs](#additional-docs)
+- [Origin Story](#origin-story)
+- [Agent Triage Workflow](#agent-triage-workflow)
+- [Command Reference](#command-reference)
+  - [threads list](#threads-list)
+  - [threads resolve](#threads-resolve)
+  - [threads resolve-all](#threads-resolve-all)
+  - [review view](#review-view)
+  - [review start / add-comment / submit](#review-start--add-comment--submit)
+  - [comments reply](#comments-reply)
+- [Git Context Inference](#git-context-inference)
+- [Backend Policy](#backend-policy)
 - [Design for LLMs & Automated Agents](#design-for-llms--automated-agents)
+- [Additional Docs](#additional-docs)
 - [Using as a Skill](#using-as-a-skill)
+- [Development](#development)
 
+---
 
+## Origin Story
 
+This tool was born from a real pain point on `nightfox-agent` PR #18: **178 review threads** from three automated reviewers (CodeRabbit, Codex, and humans). The workflow before this extension was hand-rolled GraphQL mutations, Python scripts, and purely manual triage. After: single CLI commands that an agent can compose.
+
+GitHub has had open requests for this capability since at least [cli/cli#359](https://github.com/cli/cli/issues/359) (6+ years) and [cli/cli#12419](https://github.com/cli/cli/issues/12419). `gh-pr-review` fills that gap today.
+
+---
 
 ## Quickstart
 
-The quickest path from opening a pending review to resolving threads:
-
-1. **Install or upgrade the extension.**
-
-   ```sh
-   gh extension install agynio/gh-pr-review
-   # Update an existing installation
-   gh extension upgrade agynio/gh-pr-review
-   ```
-
-
-2. **Start a pending review (GraphQL).** Capture the returned `id` (GraphQL
-   node). When run inside a git repository, `-R owner/repo` and the PR number
-   are inferred automatically from the git remote and current branch.
-
-   ```sh
-   # Explicit (works anywhere)
-   gh pr-review review --start -R owner/repo 42
-
-   # Inferred (inside a repo, on a branch with an open PR)
-   gh pr-review review --start
-
-   {
-     "id": "PRR_kwDOAAABbcdEFG12",
-     "state": "PENDING"
-   }
-   ```
-
-   Pending reviews omit `submitted_at`; the field appears after submission.
-
-3. **Add inline comments with the pending review ID (GraphQL).** The
-   `review --add-comment` command fails fast if you supply a numeric ID instead
-   of the required `PRR_…` GraphQL identifier.
-
-   ```sh
-   gh pr-review review --add-comment \
-     --review-id PRR_kwDOAAABbcdEFG12 \
-     --path internal/service.go \
-     --line 42 \
-     --body "nit: use helper" \
-     -R owner/repo 42
-
-   {
-     "id": "PRRT_kwDOAAABbcdEFG12",
-     "path": "internal/service.go",
-     "is_outdated": false,
-     "line": 42
-   }
-   ```
-
-4. **Inspect review threads (GraphQL).** `review view` surfaces pending
-   review summaries, thread state, and inline comment metadata. Thread IDs are
-   always included; enable `--include-comment-node-id` when you also need the
-   individual comment node identifiers.
-
-   ```sh
-   gh pr-review review view --reviewer octocat -R owner/repo 42
-
-   {
-     "reviews": [
-       {
-         "id": "PRR_kwDOAAABbcdEFG12",
-         "state": "COMMENTED",
-         "author_login": "octocat",
-         "comments": [
-           {
-             "thread_id": "PRRT_kwDOAAABbcdEFG12",
-             "path": "internal/service.go",
-             "author_login": "octocat",
-             "body": "nit: prefer helper",
-             "created_at": "2024-05-25T18:21:37Z",
-             "is_resolved": false,
-             "is_outdated": false,
-             "thread_comments": []
-           }
-         ]
-       }
-     ]
-   }
-   ```
-
-   Use the `thread_id` values with `comments reply` to continue discussions. If
-   you are replying inside your own pending review, pass the associated
-   `PRR_…` identifier with `--review-id`.
-
-   ```sh
-   gh pr-review comments reply \
-     --thread-id PRRT_kwDOAAABbcdEFG12 \
-     --body "Follow-up addressed in commit abc123" \
-     -R owner/repo 42
-   ```
-
-5. **Submit the review (GraphQL).** Reuse the pending review `PRR_…`
-   identifier when finalizing. Successful submissions emit a status-only
-   payload. GraphQL-level errors are returned as structured JSON for
-   troubleshooting.
-
-   ```sh
-   gh pr-review review --submit \
-     --review-id PRR_kwDOAAABbcdEFG12 \
-     --event REQUEST_CHANGES \
-     --body "Please add tests" \
-     -R owner/repo 42
-
-   {
-     "status": "Review submitted successfully"
-   }
-   ```
-
-   On GraphQL errors, the command exits non-zero after emitting:
-
-   ```json
-   {
-     "status": "Review submission failed",
-     "errors": [
-       { "message": "mutation failed", "path": ["mutation", "submitPullRequestReview"] }
-     ]
-   }
-   ```
-
-6. **Inspect and resolve threads (GraphQL).** Array responses are always `[]`
-   when no threads match.
-
-   ```sh
-   gh pr-review threads list --unresolved --mine -R owner/repo 42
-
-   [
-     {
-       "threadId": "R_ywDoABC123",
-       "isResolved": false,
-       "path": "internal/service.go",
-       "line": 42,
-       "isOutdated": false
-     }
-   ]
-   ```
-
-   ```sh
-   gh pr-review threads resolve --thread-id R_ywDoABC123 -R owner/repo 42
-   
-   {
-     "thread_node_id": "R_ywDoABC123",
-     "is_resolved": true
-   }
-   ```
-
-## Review view
-
-`gh pr-review review view` emits a GraphQL-only snapshot of pull request
-discussion. The response groups reviews → parent inline comments → thread
-replies, omitting optional fields entirely instead of returning `null`.
-
-Run it with either a combined selector or explicit flags. When inside a git
-repository, `-R` and `--pr` are inferred automatically:
-
-```sh
-# Explicit
-gh pr-review review view -R owner/repo --pr 3
-
-# Inferred (inside the repo, on a branch with an open PR)
-gh pr-review review view
-```
-
-Install or upgrade to **v1.6.0 or newer** (GraphQL-only thread resolution and minimal comment replies):
+Install or upgrade:
 
 ```sh
 gh extension install agynio/gh-pr-review
@@ -199,114 +46,379 @@ gh extension install agynio/gh-pr-review
 gh extension upgrade agynio/gh-pr-review
 ```
 
-### Command behavior
-
-- Single GraphQL operation per invocation (no REST mixing).
-- Includes all reviewers, review states, and threads by default.
-- Replies are sorted by `created_at` ascending.
-- Output exposes `author_login` only—no user objects or `html_url` fields.
-- Optional fields (`body`, `submitted_at`, `line`) are omitted when empty.
-- `comments` is omitted entirely when a review has no inline comments.
-- `thread_comments` is required for every inline comment and always present
-  (empty arrays indicate no replies).
-
-For the full canonical response structure, see docs/SCHEMAS.md.
-
-### Filters
-
-| Flag | Purpose |
-| --- | --- |
-| `--reviewer <login>` | Only include reviews authored by `<login>` (case-insensitive). |
-| `--states <list>` | Comma-separated review states (`APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, `DISMISSED`). |
-| `--unresolved` | Keep only unresolved threads. |
-| `--not_outdated` | Exclude threads marked as outdated. |
-| `--tail <n>` | Retain only the last `n` replies per thread (0 = all). The parent inline comment is always kept; only replies are trimmed. |
-| `--include-comment-node-id` | Add GraphQL comment node identifiers to parent comments and replies. |
-
-### Examples
+List unresolved threads on PR #18:
 
 ```sh
-# Default: return all reviews, states, threads
-gh pr-review review view -R owner/repo --pr 3
-
-# Unresolved threads only
-gh pr-review review view -R owner/repo --pr 3 --unresolved
-
-# Focus changes requested from a single reviewer; keep only latest reply per thread
-gh pr-review review view -R owner/repo --pr 3 --reviewer alice --states CHANGES_REQUESTED --tail 1
-
-# Drop outdated threads and include comment node IDs
-gh pr-review review view -R owner/repo --pr 3 --not_outdated --include-comment-node-id
+gh pr-review threads list 18 -R owner/repo --unresolved
 ```
 
-### Replying to threads
-
-Use the `thread_id` values surfaced in the report when replying.
+Resolve a thread with a commit link:
 
 ```sh
-gh pr-review comments reply 3 -R owner/repo \
+gh pr-review threads resolve 18 -R owner/repo --thread-id PRRT_xxx --commit HEAD
+```
+
+Resolve every unresolved thread at once:
+
+```sh
+gh pr-review threads resolve-all 18 -R owner/repo --commit abc1234
+```
+
+---
+
+## Agent Triage Workflow
+
+This is the end-to-end workflow an agent uses when facing a PR with hundreds of review threads from multiple automated reviewers.
+
+```sh
+# 1. Get the lay of the land
+gh pr-review threads list 18 -R owner/repo --unresolved
+# -> 29 unresolved threads
+
+# 2. Triage by reviewer
+gh pr-review threads list 18 -R owner/repo --author rabbit --unresolved
+# -> 27 from CodeRabbit
+
+gh pr-review threads list 18 -R owner/repo --author codex --unresolved
+# -> 2 from Codex (matches chatgpt-codex-connector)
+
+# 3. Fix the Codex findings, commit
+git commit -m "fix: lazy logger init + cross-platform path containment"
+
+# 4. Resolve with full commit traceability (reply then resolve, atomic)
+gh pr-review threads resolve 18 -R owner/repo --thread-id PRRT_xxx --commit HEAD
+# -> {"thread_node_id":"PRRT_xxx","is_resolved":true,"reply_body":"Addressed in [`bbd60fc`](https://github.com/owner/repo/commit/bbd60fc)"}
+
+# 5. Bulk-resolve all CodeRabbit threads once you've addressed them
+gh pr-review threads resolve-all 18 -R owner/repo --author rabbit --commit HEAD
+
+# 6. Check what's new since your last push
+gh pr-review threads list 18 -R owner/repo --since 2026-04-05T20:00:00Z
+
+# 7. Pipe unresolved IDs to xargs for custom bulk operations
+gh pr-review threads list 18 -R owner/repo --unresolved -o ids | \
+  xargs -I{} gh pr-review threads resolve 18 -R owner/repo --thread-id {} --commit HEAD
+```
+
+---
+
+## Command Reference
+
+### threads list
+
+List review threads on a pull request with rich filtering.
+
+```
+threads list [<number>] [flags]
+
+Flags:
+  --author <login>         Filter threads by comment author (substring, case-insensitive)
+  --unresolved             Show only unresolved threads
+  --include-resolved       Show resolved threads alongside unresolved
+  --since <RFC3339>        Filter to threads updated after this timestamp
+  -o, --output <mode>      Output mode: "json" (default) or "ids" (bare thread IDs, one per line)
+  -R, --repo <owner/repo>  Repository (inferred from git context if omitted)
+  --pr <number>            PR number (inferred from git context if omitted)
+```
+
+**Examples:**
+
+```sh
+# All unresolved threads
+gh pr-review threads list 18 -R owner/repo --unresolved
+
+# Filter to CodeRabbit findings only (substring match, case-insensitive)
+gh pr-review threads list 18 -R owner/repo --author rabbit
+# -> 163 threads
+
+# Filter to Codex findings (matches chatgpt-codex-connector)
+gh pr-review threads list 18 -R owner/repo --author codex
+# -> 15 threads
+
+# Threads updated after a specific timestamp
+gh pr-review threads list 18 -R owner/repo --since 2026-04-05T17:00:00Z
+
+# Bare thread IDs for piping (one per line)
+gh pr-review threads list 18 -R owner/repo --unresolved -o ids
+# PRRT_kwDORiDhb8547bD4
+# PRRT_kwDORiDhb8547bD5
+
+# Inside a repo with an open PR -- no -R or PR number needed
+gh pr-review threads list
+```
+
+**Sample JSON output:**
+
+```json
+[
+  {
+    "threadId": "PRRT_kwDORiDhb8547bD4",
+    "isResolved": false,
+    "path": "internal/service.go",
+    "line": 42,
+    "isOutdated": false,
+    "body": "nit: prefer helper",
+    "author": "coderabbitai"
+  }
+]
+```
+
+---
+
+### threads resolve
+
+Resolve a single thread, optionally posting a commit-linked reply first.
+
+```
+threads resolve [<number>] [flags]
+
+Flags:
+  --thread-id <id>         GraphQL thread node ID (PRRT_...) -- required
+  --commit <ref>           Post "Addressed in [<sha>](link)" reply before resolving.
+                           Accepts raw SHA or any symbolic ref (HEAD, branch name).
+                           Reply failure prevents resolution (atomic).
+  -R, --repo <owner/repo>  Repository (inferred from git context if omitted)
+  --pr <number>            PR number (inferred from git context if omitted)
+```
+
+**Examples:**
+
+```sh
+# Resolve with clickable commit link (HEAD resolved to short SHA automatically)
+gh pr-review threads resolve 18 -R owner/repo --thread-id PRRT_xxx --commit HEAD
+
+# Output:
+# {"thread_node_id":"PRRT_xxx","is_resolved":true,"reply_body":"Addressed in [`bbd60fc`](https://github.com/owner/repo/commit/bbd60fc)"}
+
+# Resolve with explicit SHA
+gh pr-review threads resolve 18 -R owner/repo --thread-id PRRT_xxx --commit abc1234
+
+# Resolve without a reply
+gh pr-review threads resolve 18 -R owner/repo --thread-id PRRT_xxx
+```
+
+The `--commit` flag uses symbolic ref resolution: pass `HEAD`, a branch name, or any `git rev-parse`-compatible ref and it resolves to the short SHA before posting. The reply is posted first; if it fails, the thread is **not** resolved.
+
+---
+
+### threads resolve-all
+
+Bulk-resolve multiple threads in one command, with optional author and commit filters.
+
+```
+threads resolve-all [<number>] [flags]
+
+Flags:
+  --author <login>         Resolve only threads matching this author (substring, case-insensitive)
+  --commit <ref>           Post commit-linked reply before each resolution
+  --include-resolved       Include already-resolved threads (re-resolve them)
+  -R, --repo <owner/repo>  Repository (inferred from git context if omitted)
+  --pr <number>            PR number (inferred from git context if omitted)
+```
+
+**Examples:**
+
+```sh
+# Resolve all unresolved threads with commit traceability
+gh pr-review threads resolve-all 18 -R owner/repo --commit abc1234
+
+# Only resolve CodeRabbit threads
+gh pr-review threads resolve-all 18 -R owner/repo --author rabbit --commit abc1234
+
+# Use HEAD (auto-resolved to short SHA)
+gh pr-review threads resolve-all 18 -R owner/repo --commit HEAD
+
+# Include already-resolved threads
+gh pr-review threads resolve-all 18 -R owner/repo --include-resolved
+```
+
+Each thread is resolved independently. Output is a JSON array of per-thread results.
+
+---
+
+### review view
+
+Get a full GraphQL snapshot of all PR reviews grouped by reviewer, with inline threads and replies.
+
+```
+review view [<number>] [flags]
+
+Flags:
+  --reviewer <login>              Only include reviews by this author
+  --states <list>                 Comma-separated: APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED
+  --unresolved                    Keep only unresolved threads
+  --not_outdated                  Exclude outdated threads
+  --tail <n>                      Keep only last n replies per thread (0 = all)
+  --include-comment-node-id       Add GraphQL comment node IDs to output
+  --include-resolved              Include resolved threads alongside unresolved
+  -R, --repo <owner/repo>         Repository (inferred from git context if omitted)
+  --pr <number>                   PR number (inferred from git context if omitted)
+```
+
+**Examples:**
+
+```sh
+# All reviews and threads
+gh pr-review review view -R owner/repo --pr 18
+
+# Include resolved threads for audit
+gh pr-review review view 18 -R owner/repo --include-resolved
+
+# Focus on one reviewer's change requests, last reply only
+gh pr-review review view -R owner/repo --pr 18 --reviewer alice --states CHANGES_REQUESTED --tail 1
+
+# Drop outdated threads
+gh pr-review review view -R owner/repo --pr 18 --not_outdated
+```
+
+**Sample output:**
+
+```json
+{
+  "reviews": [
+    {
+      "id": "PRR_kwDOAAABbcdEFG12",
+      "state": "COMMENTED",
+      "author_login": "coderabbitai",
+      "comments": [
+        {
+          "thread_id": "PRRT_kwDOAAABbcdEFG12",
+          "path": "internal/service.go",
+          "author_login": "coderabbitai",
+          "body": "nit: prefer helper",
+          "created_at": "2026-04-05T18:21:37Z",
+          "is_resolved": false,
+          "is_outdated": false,
+          "thread_comments": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### review start / add-comment / submit
+
+Start a pending review, add inline comments, and submit.
+
+```sh
+# Start a pending review
+gh pr-review review --start -R owner/repo 42
+# -> {"id": "PRR_kwDOAAABbcdEFG12", "state": "PENDING"}
+
+# Add an inline comment to the pending review
+gh pr-review review --add-comment \
+  --review-id PRR_kwDOAAABbcdEFG12 \
+  --path internal/service.go \
+  --line 42 \
+  --body "nit: use helper" \
+  -R owner/repo 42
+
+# Submit the review
+gh pr-review review --submit \
+  --review-id PRR_kwDOAAABbcdEFG12 \
+  --event REQUEST_CHANGES \
+  --body "Please add tests" \
+  -R owner/repo 42
+# -> {"status": "Review submitted successfully"}
+```
+
+---
+
+### comments reply
+
+Reply to a specific thread.
+
+```sh
+gh pr-review comments reply 42 -R owner/repo \
   --thread-id PRRT_kwDOAAABbcdEFG12 \
-  --body "Follow-up addressed in commit abc123"
-
+  --body "Addressed in commit abc123"
 ```
 
-## Backend policy
+Pass `--review-id PRR_...` when replying from inside a pending review.
 
-Each command binds to a single GitHub backend—there are no runtime fallbacks.
+---
+
+## Git Context Inference
+
+When run inside a git repository on a branch with an open PR, `gh-pr-review` infers the repository (`-R`) and PR number automatically from the git remote and current branch. You only need to specify them explicitly when working outside a repo or targeting a different repo or PR.
+
+```sh
+# Inside the repo on the PR branch -- no flags needed
+gh pr-review threads list
+gh pr-review review view
+```
+
+This inference is available for all subcommands and was added to make agent workflows cleaner when operating in-repo.
+
+---
+
+## Backend Policy
+
+Every command uses a single GitHub backend with no runtime fallbacks.
 
 | Command | Backend | Notes |
 | --- | --- | --- |
 | `review --start` | GraphQL | Opens a pending review via `addPullRequestReview`. |
-| `review --add-comment` | GraphQL | Requires a `PRR_…` review node ID. |
-| `review view` | GraphQL | Aggregates reviews, inline comments, and replies (used for thread IDs). |
-| `review --submit` | GraphQL | Finalizes a pending review via `submitPullRequestReview` using the `PRR_…` review node ID (executed through the internal `gh api graphql` wrapper). |
-| `comments reply` | GraphQL | Replies via `addPullRequestReviewThreadReply`; supply `--review-id` when responding from a pending review. |
-| `threads list` | GraphQL | Enumerates review threads for the pull request. |
-| `threads resolve` / `unresolve` | GraphQL | Mutates thread resolution via `resolveReviewThread` / `unresolveReviewThread`; supply GraphQL thread node IDs (`PRRT_…`). |
+| `review --add-comment` | GraphQL | Requires a `PRR_...` review node ID. |
+| `review view` | GraphQL | Aggregates reviews, inline comments, and replies. |
+| `review --submit` | GraphQL | Finalizes via `submitPullRequestReview`. |
+| `comments reply` | GraphQL | Replies via `addPullRequestReviewThreadReply`. |
+| `threads list` | GraphQL | Enumerates review threads with filtering. |
+| `threads resolve` / `unresolve` | GraphQL | Mutates thread resolution; supply `PRRT_...` node IDs. |
+| `threads resolve-all` | GraphQL | Bulk resolution with per-thread reply+resolve. |
 
-
-## Additional docs
-
-- [docs/USAGE.md](docs/USAGE.md) — Command-by-command inputs, outputs, and
-  examples for v1.6.0.
-- [docs/SCHEMAS.md](docs/SCHEMAS.md) — JSON schemas for each structured
-  response (optional fields omitted rather than set to null).
-- [docs/AGENTS.md](docs/AGENTS.md) — Agent-focused workflows, prompts, and
-  best practices.
+---
 
 ## Design for LLMs & Automated Agents
 
-`gh-pr-review` is designed to give LLMs and agents the **exact PR review context they need** — without the noisy, multi-step GitHub API workflow.
+`gh-pr-review` is purpose-built for agents operating at scale. Everything about its output format, filter flags, and output modes was designed around the constraint that an agent is consuming the output.
 
-### Why it's LLM-friendly
+### Why it's agent-native
 
-- **Replaces multi-call API chains with one command**  
-  Instead of calling `list reviews → list thread comments → list comments`,  
-  a single `gh pr-review review view` command returns the entire, assembled review structure.
+- **One command replaces a chain of API calls.**  
+  Instead of `list reviews -> list threads -> list comments per thread`, a single `gh pr-review review view` returns the fully assembled review structure.
 
-- **Deterministic, stable output**  
-  Consistent formatting, stable ordering, and predictable field names make parsing reliable for agents.
+- **`--author` substring filtering.**  
+  Agents often know the bot name but not the exact login. `--author rabbit` matches `coderabbitai`, `coderabbit-bot`, and any variation — case-insensitively.
 
-- **Compact, meaningful JSON**  
-  Only essential fields are returned. Low-signal metadata (URLs, hashes, unused fields) is stripped out to reduce token usage.
+- **`-o ids` output mode for piping.**  
+  Bare thread IDs on stdout, one per line — designed to pipe into `xargs` or agent loops without any parsing.
 
-- **Pre-joined review threads**  
-  Threads come fully reconstructed with inline context — no need for agents to merge comments manually.
+- **`--commit HEAD` with symbolic ref resolution.**  
+  Agents commit code then need to reference that commit. Pass `HEAD` and the tool resolves it to the short SHA and constructs a clickable link automatically.
 
-- **Server-side filters for token efficiency**  
-  Options like `--unresolved` and `--tail` help reduce payload size and keep inputs affordable for LLMs.
+- **Atomic reply-then-resolve.**  
+  When `--commit` is set, the reply is posted first. If posting fails, the thread stays unresolved. No silent partial states.
 
+- **`--since` for incremental workflows.**  
+  Agents re-running after a push only want threads updated since the last run. `--since <RFC3339>` makes this exact.
+
+- **`threads resolve-all` for O(1) triage.**  
+  After addressing CodeRabbit findings, one command resolves all matching threads with commit links. No loops needed.
+
+- **Compact, deterministic JSON.**  
+  Optional fields are omitted rather than null. Field order is stable. Token cost is minimized.
 
 > "A good tool definition should define a clear, narrow purpose, return exactly the meaningful context the agent needs, and avoid burdening the model with low-signal intermediate results."
 
+---
+
+## Additional Docs
+
+- [docs/USAGE.md](docs/USAGE.md) — Command-by-command inputs, outputs, and examples.
+- [docs/SCHEMAS.md](docs/SCHEMAS.md) — JSON schemas for every structured response.
+- [docs/AGENTS.md](docs/AGENTS.md) — Agent-focused workflows, prompts, and best practices.
+
+---
 
 ## Using as a Skill
 
 `gh-pr-review` can be used as a reusable skill for AI coding agents via [Vercel's add-skill package](https://github.com/vercel-labs/add-skill).
 
 ### Installation as a Skill
-
-To add gh-pr-review as a skill to your AI coding agent:
 
 ```sh
 npx @vercel/add-skill https://github.com/agynio/gh-pr-review
@@ -321,24 +433,23 @@ This command will:
 
 Once installed, your AI coding agent can:
 
+- **Triage PR threads**: Filter by author, resolution state, and timestamp
 - **View PR reviews**: Get complete inline comment threads with file context
 - **Reply to comments**: Respond to review feedback programmatically
-- **Resolve threads**: Mark discussions as resolved after addressing feedback
+- **Resolve threads**: Mark discussions as resolved, with commit links, atomically
+- **Bulk resolve**: Resolve all threads matching a filter in one command
 - **Create reviews**: Start pending reviews and add inline comments
-- **Filter intelligently**: Focus on unresolved, non-outdated comments by specific reviewers
 
 All commands return structured JSON optimized for agent consumption with minimal tokens and maximum context.
 
 ### Example Agent Workflow
 
 ```
-User: "Show me unresolved comments on this PR"
-Agent: gh pr-review review view --unresolved --not_outdated
-Agent: [Parses JSON, summarizes 3 unresolved threads]
-
-User: "Reply to the comment about error handling"
-Agent: gh pr-review comments reply --thread-id PRRT_... --body "Fixed in commit abc123"
-Agent: gh pr-review threads resolve --thread-id PRRT_...
+User: "Address all CodeRabbit findings on this PR"
+Agent: gh pr-review threads list --author rabbit --unresolved
+Agent: [Reads threads, applies fixes, commits]
+Agent: gh pr-review threads resolve-all --author rabbit --commit HEAD
+Agent: [All CodeRabbit threads resolved with clickable commit links]
 ```
 
 ### Skill Documentation
@@ -349,6 +460,8 @@ See [SKILL.md](SKILL.md) for complete skill documentation including:
 - Best practices for agents
 - Common workflow patterns
 
+---
+
 ## Development
 
 Run the test suite and linters locally with cgo disabled (matching the release build):
@@ -358,6 +471,4 @@ CGO_ENABLED=0 go test ./...
 CGO_ENABLED=0 golangci-lint run
 ```
 
-Releases are built using the
-[`cli/gh-extension-precompile`](https://github.com/cli/gh-extension-precompile)
-workflow to publish binaries for macOS, Linux, and Windows.
+Releases are built using the [`cli/gh-extension-precompile`](https://github.com/cli/gh-extension-precompile) workflow to publish binaries for macOS, Linux, and Windows.

--- a/SKILL.md
+++ b/SKILL.md
@@ -32,6 +32,13 @@ First, ensure the extension is installed:
 gh extension install agynio/gh-pr-review
 ```
 
+## Repository and PR Inference
+
+When run inside a git repository, `-R owner/repo` and `--pr` / PR number are
+**inferred automatically** from the git remote and current branch. You only need
+to specify them explicitly when working outside a repo or targeting a different
+repo/PR.
+
 ## Core Commands
 
 ### 1. View All Reviews and Threads
@@ -39,7 +46,11 @@ gh extension install agynio/gh-pr-review
 Get complete review context with inline comments and thread replies:
 
 ```sh
+# Explicit
 gh pr-review review view -R owner/repo --pr <number>
+
+# Inferred (inside a repo, on a branch with an open PR)
+gh pr-review review view
 ```
 
 **Useful filters:**
@@ -150,32 +161,33 @@ Example output structure:
 
 ## Best Practices
 
-1. **Always use `-R owner/repo`** to specify the repository explicitly
-2. **Use `--unresolved` and `--not_outdated`** to focus on actionable comments
-3. **Save thread_id values** from `review view` output for replying
-4. **Filter by reviewer** when dealing with specific review feedback
-5. **Use `--tail 1`** to reduce output size by keeping only latest replies
-6. **Parse JSON output** instead of trying to scrape text
+1. **Rely on inference** when inside a git repo — `-R` and `--pr` are optional
+2. **Use `-R owner/repo`** explicitly when targeting a different repository
+3. **Use `--unresolved` and `--not_outdated`** to focus on actionable comments
+4. **Save thread_id values** from `review view` output for replying
+5. **Filter by reviewer** when dealing with specific review feedback
+6. **Use `--tail 1`** to reduce output size by keeping only latest replies
+7. **Parse JSON output** instead of trying to scrape text
 
 ## Common Workflows
 
 ### Get Unresolved Comments for Current PR
 
 ```sh
-gh pr-review review view --unresolved --not_outdated -R owner/repo --pr $(gh pr view --json number -q .number)
+gh pr-review review view --unresolved --not_outdated
 ```
 
 ### Reply to All Unresolved Comments
 
-1. Get unresolved threads: `gh pr-review threads list --unresolved -R owner/repo <pr>`
-2. For each thread_id, reply: `gh pr-review comments reply <pr> -R owner/repo --thread-id <id> --body "..."`
-3. Optionally resolve: `gh pr-review threads resolve <pr> -R owner/repo --thread-id <id>`
+1. Get unresolved threads: `gh pr-review threads list --unresolved`
+2. For each thread_id, reply: `gh pr-review comments reply --thread-id <id> --body "..."`
+3. Optionally resolve: `gh pr-review threads resolve --thread-id <id>`
 
 ### Create Review with Inline Comments
 
-1. Start: `gh pr-review review --start -R owner/repo <pr>`
-2. Add comments: `gh pr-review review --add-comment -R owner/repo <pr> --review-id <PRR_...> --path <file> --line <num> --body "..."`
-3. Submit: `gh pr-review review --submit -R owner/repo <pr> --review-id <PRR_...> --event REQUEST_CHANGES --body "Summary"`
+1. Start: `gh pr-review review --start`
+2. Add comments: `gh pr-review review --add-comment --review-id <PRR_...> --path <file> --line <num> --body "..."`
+3. Submit: `gh pr-review review --submit --review-id <PRR_...> --event REQUEST_CHANGES --body "Summary"`
 
 ## Important Notes
 

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -80,11 +80,13 @@ type commentsReplyOptions struct {
 }
 
 func runCommentsReply(cmd *cobra.Command, opts *commentsReplyOptions) error {
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	hostEnv := os.Getenv("GH_HOST")
 	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
 	if err != nil {

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -5,3 +5,21 @@ import "github.com/agynio/gh-pr-review/internal/ghcli"
 var apiClientFactory = func(host string) ghcli.API {
 	return &ghcli.Client{Host: host}
 }
+
+// inferRepo fills in repo from the current git context when not explicitly provided.
+func inferRepo(repo *string) {
+	if *repo == "" {
+		if r, err := ghcli.CurrentRepo(); err == nil {
+			*repo = r
+		}
+	}
+}
+
+// inferPR fills in the PR number from the current branch when not explicitly provided.
+func inferPR(selector string, pr *int) {
+	if selector == "" && *pr == 0 {
+		if n, err := ghcli.CurrentPR(); err == nil {
+			*pr = n
+		}
+	}
+}

--- a/cmd/react.go
+++ b/cmd/react.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/agynio/gh-pr-review/internal/reactions"
+)
+
+func newReactCommand() *cobra.Command {
+	var reactionType string
+
+	cmd := &cobra.Command{
+		Use:   "react <node-id>",
+		Short: "Add a reaction to any reactable GitHub node",
+		Long: `Add a reaction to any reactable GitHub node (review comment, issue comment, PR review body, etc.).
+
+The node-id is the GraphQL node ID of the target object. Use --type to specify the reaction.
+
+Valid reaction types: ` + strings.Join(reactions.ValidReactionNames(), ", "),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nodeID := strings.TrimSpace(args[0])
+			if nodeID == "" {
+				return fmt.Errorf("node-id is required")
+			}
+
+			reactionType = strings.TrimSpace(reactionType)
+			if reactionType == "" {
+				return fmt.Errorf("--type is required")
+			}
+
+			if err := reactions.Validate(reactionType); err != nil {
+				return fmt.Errorf("--type: %w", err)
+			}
+
+			api := apiClientFactory("")
+			if err := reactions.React(api, nodeID, reactionType); err != nil {
+				return err
+			}
+
+			result := map[string]string{
+				"node_id":  nodeID,
+				"reaction": reactionType,
+				"status":   "added",
+			}
+			return encodeJSON(cmd, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&reactionType, "type", "", "Reaction type (required): "+strings.Join(reactions.ValidReactionNames(), ", "))
+	_ = cmd.MarkFlagRequired("type")
+
+	return cmd
+}

--- a/cmd/react_test.go
+++ b/cmd/react_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReactCommandValid(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	var capturedQuery string
+	var capturedVars map[string]interface{}
+
+	fake := &commandFakeAPI{}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		capturedQuery = query
+		capturedVars = variables
+		return nil
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"react", "IC_kwDOTest", "--type", "thumbs_up"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	// Verify the GraphQL mutation was called
+	assert.Contains(t, capturedQuery, "addReaction")
+	assert.Equal(t, "IC_kwDOTest", capturedVars["subjectId"])
+	assert.Equal(t, "THUMBS_UP", capturedVars["content"])
+
+	// Verify JSON output
+	var output map[string]string
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
+	assert.Equal(t, "IC_kwDOTest", output["node_id"])
+	assert.Equal(t, "thumbs_up", output["reaction"])
+	assert.Equal(t, "added", output["status"])
+}
+
+func TestReactCommandInvalidType(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	fake := &commandFakeAPI{}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"react", "IC_kwDOTest", "--type", "invalid_reaction"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid reaction")
+}
+
+func TestReactCommandMissingNodeID(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"react", "--type", "thumbs_up"})
+
+	err := root.Execute()
+	// cobra treats --type as the positional arg when no node-id is given,
+	// or fails on ExactArgs(1) — either way it should error
+	require.Error(t, err)
+}
+
+func TestReactCommandMissingType(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"react", "IC_kwDOTest"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required flag")
+}
+
+func TestReactCommandGraphQLError(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	fake := &commandFakeAPI{}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		return errors.New("GraphQL: Could not resolve to a node")
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"react", "INVALID_NODE", "--type", "heart"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Could not resolve to a node")
+}
+
+func TestReactCommandAllReactionTypes(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	reactionTypes := []struct {
+		cli     string
+		graphql string
+	}{
+		{"thumbs_up", "THUMBS_UP"},
+		{"thumbs_down", "THUMBS_DOWN"},
+		{"laugh", "LAUGH"},
+		{"hooray", "HOORAY"},
+		{"confused", "CONFUSED"},
+		{"heart", "HEART"},
+		{"rocket", "ROCKET"},
+		{"eyes", "EYES"},
+	}
+
+	for _, rt := range reactionTypes {
+		t.Run(rt.cli, func(t *testing.T) {
+			var capturedContent string
+			fake := &commandFakeAPI{}
+			fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+				capturedContent = variables["content"].(string)
+				return nil
+			}
+			apiClientFactory = func(host string) ghcli.API { return fake }
+
+			root := newRootCommand()
+			stdout := &bytes.Buffer{}
+			root.SetOut(stdout)
+			root.SetErr(&bytes.Buffer{})
+			root.SetArgs([]string{"react", "IC_test", "--type", rt.cli})
+
+			err := root.Execute()
+			require.NoError(t, err)
+			assert.Equal(t, rt.graphql, capturedContent)
+		})
+	}
+}

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -81,11 +81,13 @@ func runReview(cmd *cobra.Command, opts *reviewOptions) error {
 		return errors.New("specify exactly one of --start, --add-comment, or --submit")
 	}
 
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	hostEnv := os.Getenv("GH_HOST")
 	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
 	if err != nil {

--- a/cmd/review_view.go
+++ b/cmd/review_view.go
@@ -60,6 +60,7 @@ func runReviewView(cmd *cobra.Command, opts *reviewViewOptions) error {
 		return fmt.Errorf("invalid --tail value %d: must be non-negative", opts.TailReplies)
 	}
 
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
@@ -70,6 +71,7 @@ func runReviewView(cmd *cobra.Command, opts *reviewViewOptions) error {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	identity, err := resolver.Resolve(selector, opts.Repo, os.Getenv("GH_HOST"))
 	if err != nil {
 		return err

--- a/cmd/review_view.go
+++ b/cmd/review_view.go
@@ -36,7 +36,7 @@ func newReviewViewCommand() *cobra.Command {
 	cmd.Flags().IntVar(&opts.TailReplies, "tail", 0, "Limit to the last N replies per thread (0 = all)")
 	cmd.Flags().BoolVar(&opts.IncludeCommentNodeID, "include-comment-node-id", false, "Include comment_node_id fields for parent comments and replies")
 	cmd.Flags().StringVar(&opts.Author, "author", "", "Filter threads to those containing a comment by this author login (case-insensitive)")
-	cmd.Flags().BoolVar(&opts.All, "all", false, "Include resolved threads in output (overrides --unresolved)")
+	cmd.Flags().BoolVar(&opts.All, "include-resolved", false, "Include resolved threads (overrides --unresolved)")
 
 	return cmd
 }

--- a/cmd/review_view.go
+++ b/cmd/review_view.go
@@ -35,7 +35,7 @@ func newReviewViewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.NotOutdated, "not_outdated", false, "Exclude outdated threads")
 	cmd.Flags().IntVar(&opts.TailReplies, "tail", 0, "Limit to the last N replies per thread (0 = all)")
 	cmd.Flags().BoolVar(&opts.IncludeCommentNodeID, "include-comment-node-id", false, "Include comment_node_id fields for parent comments and replies")
-	cmd.Flags().StringVar(&opts.Author, "author", "", "Filter threads to those containing a comment by this author login (case-insensitive)")
+	cmd.Flags().StringVar(&opts.Author, "author", "", "Filter threads to those containing a comment by this author login (substring, case-insensitive)")
 	cmd.Flags().BoolVar(&opts.IncludeResolved, "include-resolved", false, "Include resolved threads (overrides --unresolved)")
 
 	return cmd

--- a/cmd/review_view.go
+++ b/cmd/review_view.go
@@ -35,6 +35,8 @@ func newReviewViewCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.NotOutdated, "not_outdated", false, "Exclude outdated threads")
 	cmd.Flags().IntVar(&opts.TailReplies, "tail", 0, "Limit to the last N replies per thread (0 = all)")
 	cmd.Flags().BoolVar(&opts.IncludeCommentNodeID, "include-comment-node-id", false, "Include comment_node_id fields for parent comments and replies")
+	cmd.Flags().StringVar(&opts.Author, "author", "", "Filter threads to those containing a comment by this author login (case-insensitive)")
+	cmd.Flags().BoolVar(&opts.All, "all", false, "Include resolved threads in output (overrides --unresolved)")
 
 	return cmd
 }
@@ -49,6 +51,8 @@ type reviewViewOptions struct {
 	NotOutdated          bool
 	TailReplies          int
 	IncludeCommentNodeID bool
+	Author               string
+	All                  bool
 }
 
 func runReviewView(cmd *cobra.Command, opts *reviewViewOptions) error {
@@ -80,6 +84,8 @@ func runReviewView(cmd *cobra.Command, opts *reviewViewOptions) error {
 		RequireNotOutdated:   opts.NotOutdated,
 		TailReplies:          opts.TailReplies,
 		IncludeCommentNodeID: opts.IncludeCommentNodeID,
+		Author:               strings.TrimSpace(opts.Author),
+		IncludeResolved:      opts.All,
 	})
 	if err != nil {
 		return err

--- a/cmd/review_view.go
+++ b/cmd/review_view.go
@@ -36,7 +36,7 @@ func newReviewViewCommand() *cobra.Command {
 	cmd.Flags().IntVar(&opts.TailReplies, "tail", 0, "Limit to the last N replies per thread (0 = all)")
 	cmd.Flags().BoolVar(&opts.IncludeCommentNodeID, "include-comment-node-id", false, "Include comment_node_id fields for parent comments and replies")
 	cmd.Flags().StringVar(&opts.Author, "author", "", "Filter threads to those containing a comment by this author login (case-insensitive)")
-	cmd.Flags().BoolVar(&opts.All, "include-resolved", false, "Include resolved threads (overrides --unresolved)")
+	cmd.Flags().BoolVar(&opts.IncludeResolved, "include-resolved", false, "Include resolved threads (overrides --unresolved)")
 
 	return cmd
 }
@@ -52,7 +52,7 @@ type reviewViewOptions struct {
 	TailReplies          int
 	IncludeCommentNodeID bool
 	Author               string
-	All                  bool
+	IncludeResolved      bool
 }
 
 func runReviewView(cmd *cobra.Command, opts *reviewViewOptions) error {
@@ -87,7 +87,7 @@ func runReviewView(cmd *cobra.Command, opts *reviewViewOptions) error {
 		TailReplies:          opts.TailReplies,
 		IncludeCommentNodeID: opts.IncludeCommentNodeID,
 		Author:               strings.TrimSpace(opts.Author),
-		IncludeResolved:      opts.All,
+		IncludeResolved:      opts.IncludeResolved,
 	})
 	if err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ func newRootCommand() *cobra.Command {
 	cmd.AddCommand(newReviewCommand())
 	cmd.AddCommand(newThreadsCommand())
 
+	cmd.AddCommand(newReactCommand())
 	return cmd
 }
 

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -48,6 +48,7 @@ func newThreadsListCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.MineOnly, "mine", false, "Show only threads involving or resolvable by the viewer")
 	cmd.Flags().StringVar(&opts.Author, "author", "", "Filter threads to those containing a comment by this author login (case-insensitive)")
 	cmd.Flags().StringVar(&opts.Since, "since", "", "Only include threads updated at or after this RFC3339 timestamp")
+	cmd.Flags().StringVarP(&opts.Output, "output", "o", "", "Output format: 'ids' prints one thread ID per line")
 	cmd.PersistentFlags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
 	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 
@@ -62,6 +63,7 @@ type threadsListOptions struct {
 	MineOnly       bool
 	Author         string
 	Since          string
+	Output         string
 }
 
 
@@ -95,6 +97,15 @@ func runThreadsList(cmd *cobra.Command, opts *threadsListOptions) error {
 	payload, err := service.List(identity, listOpts)
 	if err != nil {
 		return err
+	}
+
+	if strings.TrimSpace(opts.Output) == "ids" {
+		ids := make([]string, len(payload))
+		for i, t := range payload {
+			ids[i] = t.ThreadID
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), strings.Join(ids, "\n"))
+		return nil
 	}
 
 	return encodeJSON(cmd, payload)

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -68,11 +68,13 @@ type threadsListOptions struct {
 
 
 func runThreadsList(cmd *cobra.Command, opts *threadsListOptions) error {
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	hostEnv := os.Getenv("GH_HOST")
 	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
 	if err != nil {
@@ -181,11 +183,13 @@ func runThreadsUnresolve(cmd *cobra.Command, opts *threadsMutationOptions) error
 }
 
 func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolve bool) error {
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	hostEnv := os.Getenv("GH_HOST")
 	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
 	if err != nil {

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -67,7 +67,6 @@ type threadsListOptions struct {
 	Output         string
 }
 
-
 func runThreadsList(cmd *cobra.Command, opts *threadsListOptions) error {
 	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
@@ -240,7 +239,6 @@ func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolv
 	return encodeJSON(cmd, result)
 }
 
-
 // newThreadsResolveAllCommand creates the resolve-all subcommand.
 func newThreadsResolveAllCommand() *cobra.Command {
 	opts := &threadsResolveAllOptions{}
@@ -332,10 +330,14 @@ func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) er
 var hexSHARe = regexp.MustCompile(`(?i)^[0-9a-f]{7,40}$`)
 
 func resolveCommitRef(ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", fmt.Errorf("git ref is required")
+	}
 	if hexSHARe.MatchString(ref) {
 		return ref, nil
 	}
-	out, err := exec.Command("git", "rev-parse", "--short", "--", ref).Output()
+	out, err := exec.Command("git", "rev-parse", "--verify", "--short", "--end-of-options", ref+"^{commit}").Output()
 	if err != nil {
 		return "", fmt.Errorf("cannot resolve git ref %q: %w", ref, err)
 	}

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/agynio/gh-pr-review/internal/reactions"
 	"github.com/agynio/gh-pr-review/internal/resolver"
 	"github.com/agynio/gh-pr-review/internal/threads"
 )
@@ -176,7 +177,7 @@ func (o *threadsMutationOptions) Validate() error {
 		return errors.New("--thread-id is required")
 	}
 	if o.React != "" {
-		if _, ok := threads.ValidReactions[o.React]; !ok {
+		if _, ok := reactions.ValidReactions[o.React]; !ok {
 			return fmt.Errorf("--react: invalid reaction %q; valid values: thumbs_up, thumbs_down, laugh, hooray, confused, heart, rocket, eyes", o.React)
 		}
 	}
@@ -218,7 +219,7 @@ func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolv
 	}
 	var reaction string
 	if opts.React != "" {
-		reaction = threads.ValidReactions[opts.React]
+		reaction = reactions.ValidReactions[opts.React]
 	}
 	action := threads.ActionOptions{
 		ThreadID: strings.TrimSpace(opts.ThreadID),
@@ -282,7 +283,7 @@ func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) er
 	}
 
 	if opts.React != "" {
-		if _, ok := threads.ValidReactions[opts.React]; !ok {
+		if _, ok := reactions.ValidReactions[opts.React]; !ok {
 			return fmt.Errorf("--react: invalid reaction %q; valid values: thumbs_up, thumbs_down, laugh, hooray, confused, heart, rocket, eyes", opts.React)
 		}
 	}
@@ -310,7 +311,7 @@ func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) er
 
 	var reaction string
 	if opts.React != "" {
-		reaction = threads.ValidReactions[opts.React]
+		reaction = reactions.ValidReactions[opts.React]
 	}
 
 	service := threads.NewService(apiClientFactory(identity.Host))

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -20,6 +23,7 @@ func newThreadsCommand() *cobra.Command {
 	cmd.AddCommand(newThreadsListCommand())
 	cmd.AddCommand(newThreadsResolveCommand())
 	cmd.AddCommand(newThreadsUnresolveCommand())
+	cmd.AddCommand(newThreadsResolveAllCommand())
 
 	return cmd
 }
@@ -176,4 +180,87 @@ func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolv
 		return err
 	}
 	return encodeJSON(cmd, result)
+	return encodeJSON(cmd, result)
+}
+
+
+// newThreadsResolveAllCommand creates the resolve-all subcommand.
+func newThreadsResolveAllCommand() *cobra.Command {
+	opts := &threadsResolveAllOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "resolve-all [<number> | <url>]",
+		Short: "Resolve all matching review threads for a pull request",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Selector = args[0]
+			}
+			return runThreadsResolveAll(cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Author, "author", "", "Only resolve threads by this author")
+	cmd.Flags().StringVar(&opts.Commit, "commit", "", "Attach commit SHA to each resolution reply")
+	cmd.Flags().BoolVar(&opts.Unresolved, "unresolved", true, "Only resolve unresolved threads (default true)")
+	cmd.PersistentFlags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format (required)")
+	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+
+	return cmd
+}
+
+type threadsResolveAllOptions struct {
+	Repo       string
+	Pull       int
+	Selector   string
+	Author     string
+	Commit     string
+	Unresolved bool
+}
+
+func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) error {
+	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
+	if err != nil {
+		return err
+	}
+
+	hostEnv := os.Getenv("GH_HOST")
+	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
+	if err != nil {
+		return err
+	}
+
+	commit := strings.TrimSpace(opts.Commit)
+	if commit != "" {
+		commit, err = resolveCommitRef(commit)
+		if err != nil {
+			return fmt.Errorf("--commit: %w", err)
+		}
+	}
+
+	service := threads.NewService(apiClientFactory(identity.Host))
+	results, err := service.ResolveAll(identity, threads.ResolveAllOptions{
+		Author:     strings.TrimSpace(opts.Author),
+		Commit:     commit,
+		Unresolved: opts.Unresolved,
+	})
+	if err != nil {
+		return err
+	}
+	return encodeJSON(cmd, results)
+}
+
+// resolveCommitRef converts symbolic git refs (e.g. HEAD, branch names) to
+// short SHAs. If ref already looks like a hex SHA it is returned unchanged.
+var hexSHARe = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+
+func resolveCommitRef(ref string) (string, error) {
+	if hexSHARe.MatchString(ref) {
+		return ref, nil
+	}
+	out, err := exec.Command("git", "rev-parse", "--short", ref).Output()
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve git ref %q: %w", ref, err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -193,7 +193,14 @@ func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolv
 	}
 
 	service := threads.NewService(apiClientFactory(identity.Host))
-	action := threads.ActionOptions{ThreadID: strings.TrimSpace(opts.ThreadID), Commit: strings.TrimSpace(opts.Commit)}
+	commit := strings.TrimSpace(opts.Commit)
+	if commit != "" {
+		commit, err = resolveCommitRef(commit)
+		if err != nil {
+			return fmt.Errorf("--commit: %w", err)
+		}
+	}
+	action := threads.ActionOptions{ThreadID: strings.TrimSpace(opts.ThreadID), Commit: commit}
 
 	var result threads.ActionResult
 	if resolve {

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -154,6 +154,8 @@ func newThreadsMutationCommand(resolve bool) *cobra.Command {
 	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 	if resolve {
 		cmd.Flags().StringVar(&opts.Commit, "commit", "", "Post a reply linking to this commit SHA before resolving")
+		cmd.Flags().StringVar(&opts.React, "react", "", "Add a reaction to the first comment (thumbs_up, thumbs_down, laugh, hooray, confused, heart, rocket, eyes)")
+		cmd.Flags().StringVar(&opts.Message, "message", "", "Post a reply message before resolving (used with --react thumbs_down)")
 	}
 
 	return cmd
@@ -165,16 +167,26 @@ type threadsMutationOptions struct {
 	Selector string
 	ThreadID string
 	Commit   string
+	React    string
+	Message  string
 }
 
 func (o *threadsMutationOptions) Validate() error {
 	if strings.TrimSpace(o.ThreadID) == "" {
 		return errors.New("--thread-id is required")
 	}
+	if o.React != "" {
+		if _, ok := threads.ValidReactions[o.React]; !ok {
+			return fmt.Errorf("--react: invalid reaction %q; valid values: thumbs_up, thumbs_down, laugh, hooray, confused, heart, rocket, eyes", o.React)
+		}
+	}
 	return nil
 }
 
 func runThreadsResolve(cmd *cobra.Command, opts *threadsMutationOptions) error {
+	if opts.Commit == "" && opts.React != "thumbs_down" {
+		return fmt.Errorf("must provide --commit (bug was fixed) or --react thumbs_down --message 'reason' (not a bug)")
+	}
 	return runThreadsMutation(cmd, opts, true)
 }
 
@@ -204,7 +216,16 @@ func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolv
 			return fmt.Errorf("--commit: %w", err)
 		}
 	}
-	action := threads.ActionOptions{ThreadID: strings.TrimSpace(opts.ThreadID), Commit: commit}
+	var reaction string
+	if opts.React != "" {
+		reaction = threads.ValidReactions[opts.React]
+	}
+	action := threads.ActionOptions{
+		ThreadID: strings.TrimSpace(opts.ThreadID),
+		Commit:   commit,
+		React:    reaction,
+		Message:  strings.TrimSpace(opts.Message),
+	}
 
 	var result threads.ActionResult
 	if resolve {
@@ -237,6 +258,7 @@ func newThreadsResolveAllCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.Author, "author", "", "Only resolve threads by this author")
 	cmd.Flags().StringVar(&opts.Commit, "commit", "", "Attach commit SHA to each resolution reply")
+	cmd.Flags().StringVar(&opts.React, "react", "", "Add a reaction to each thread's first comment after resolving (thumbs_up, thumbs_down, laugh, hooray, confused, heart, rocket, eyes)")
 	cmd.Flags().BoolVar(&opts.IncludeResolved, "include-resolved", false, "Also resolve already-resolved threads")
 	cmd.PersistentFlags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format (required)")
 	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
@@ -245,15 +267,26 @@ func newThreadsResolveAllCommand() *cobra.Command {
 }
 
 type threadsResolveAllOptions struct {
-	Repo       string
-	Pull       int
-	Selector   string
-	Author     string
-	Commit     string
+	Repo            string
+	Pull            int
+	Selector        string
+	Author          string
+	Commit          string
+	React           string
 	IncludeResolved bool
 }
 
 func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) error {
+	if opts.Commit == "" {
+		return fmt.Errorf("--commit is required for resolve-all")
+	}
+
+	if opts.React != "" {
+		if _, ok := threads.ValidReactions[opts.React]; !ok {
+			return fmt.Errorf("--react: invalid reaction %q; valid values: thumbs_up, thumbs_down, laugh, hooray, confused, heart, rocket, eyes", opts.React)
+		}
+	}
+
 	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
@@ -275,10 +308,16 @@ func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) er
 		}
 	}
 
+	var reaction string
+	if opts.React != "" {
+		reaction = threads.ValidReactions[opts.React]
+	}
+
 	service := threads.NewService(apiClientFactory(identity.Host))
 	results, err := service.ResolveAll(identity, threads.ResolveAllOptions{
 		Author:     strings.TrimSpace(opts.Author),
 		Commit:     commit,
+		React:      reaction,
 		Unresolved: !opts.IncludeResolved,
 	})
 	if err != nil {

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -41,6 +41,7 @@ func newThreadsListCommand() *cobra.Command {
 
 	cmd.Flags().BoolVar(&opts.UnresolvedOnly, "unresolved", false, "Filter to unresolved threads only")
 	cmd.Flags().BoolVar(&opts.MineOnly, "mine", false, "Show only threads involving or resolvable by the viewer")
+	cmd.Flags().StringVar(&opts.Author, "author", "", "Filter threads to those containing a comment by this author login (case-insensitive)")
 	cmd.PersistentFlags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
 	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 
@@ -53,6 +54,7 @@ type threadsListOptions struct {
 	Selector       string
 	UnresolvedOnly bool
 	MineOnly       bool
+	Author         string
 }
 
 func runThreadsList(cmd *cobra.Command, opts *threadsListOptions) error {
@@ -71,6 +73,7 @@ func runThreadsList(cmd *cobra.Command, opts *threadsListOptions) error {
 	payload, err := service.List(identity, threads.ListOptions{
 		OnlyUnresolved: opts.UnresolvedOnly,
 		MineOnly:       opts.MineOnly,
+		Author:         strings.TrimSpace(opts.Author),
 	})
 	if err != nil {
 		return err
@@ -118,6 +121,9 @@ func newThreadsMutationCommand(resolve bool) *cobra.Command {
 	cmd.Flags().StringVar(&opts.ThreadID, "thread-id", "", "GraphQL node ID for the review thread")
 	cmd.PersistentFlags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
 	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	if resolve {
+		cmd.Flags().StringVar(&opts.Commit, "commit", "", "Post a reply linking to this commit SHA before resolving")
+	}
 
 	return cmd
 }
@@ -127,6 +133,7 @@ type threadsMutationOptions struct {
 	Pull     int
 	Selector string
 	ThreadID string
+	Commit   string
 }
 
 func (o *threadsMutationOptions) Validate() error {
@@ -157,7 +164,7 @@ func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolv
 	}
 
 	service := threads.NewService(apiClientFactory(identity.Host))
-	action := threads.ActionOptions{ThreadID: strings.TrimSpace(opts.ThreadID)}
+	action := threads.ActionOptions{ThreadID: strings.TrimSpace(opts.ThreadID), Commit: strings.TrimSpace(opts.Commit)}
 
 	var result threads.ActionResult
 	if resolve {

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -212,7 +212,6 @@ func runThreadsMutation(cmd *cobra.Command, opts *threadsMutationOptions, resolv
 		return err
 	}
 	return encodeJSON(cmd, result)
-	return encodeJSON(cmd, result)
 }
 
 
@@ -234,7 +233,7 @@ func newThreadsResolveAllCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.Author, "author", "", "Only resolve threads by this author")
 	cmd.Flags().StringVar(&opts.Commit, "commit", "", "Attach commit SHA to each resolution reply")
-	cmd.Flags().BoolVar(&opts.Unresolved, "unresolved", true, "Only resolve unresolved threads (default true)")
+	cmd.Flags().BoolVar(&opts.IncludeResolved, "include-resolved", false, "Also resolve already-resolved threads")
 	cmd.PersistentFlags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format (required)")
 	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 
@@ -247,7 +246,7 @@ type threadsResolveAllOptions struct {
 	Selector   string
 	Author     string
 	Commit     string
-	Unresolved bool
+	IncludeResolved bool
 }
 
 func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) error {
@@ -274,7 +273,7 @@ func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) er
 	results, err := service.ResolveAll(identity, threads.ResolveAllOptions{
 		Author:     strings.TrimSpace(opts.Author),
 		Commit:     commit,
-		Unresolved: opts.Unresolved,
+		Unresolved: !opts.IncludeResolved,
 	})
 	if err != nil {
 		return err
@@ -284,13 +283,13 @@ func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) er
 
 // resolveCommitRef converts symbolic git refs (e.g. HEAD, branch names) to
 // short SHAs. If ref already looks like a hex SHA it is returned unchanged.
-var hexSHARe = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+var hexSHARe = regexp.MustCompile(`(?i)^[0-9a-f]{7,40}$`)
 
 func resolveCommitRef(ref string) (string, error) {
 	if hexSHARe.MatchString(ref) {
 		return ref, nil
 	}
-	out, err := exec.Command("git", "rev-parse", "--short", ref).Output()
+	out, err := exec.Command("git", "rev-parse", "--short", "--", ref).Output()
 	if err != nil {
 		return "", fmt.Errorf("cannot resolve git ref %q: %w", ref, err)
 	}

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -46,6 +47,7 @@ func newThreadsListCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.UnresolvedOnly, "unresolved", false, "Filter to unresolved threads only")
 	cmd.Flags().BoolVar(&opts.MineOnly, "mine", false, "Show only threads involving or resolvable by the viewer")
 	cmd.Flags().StringVar(&opts.Author, "author", "", "Filter threads to those containing a comment by this author login (case-insensitive)")
+	cmd.Flags().StringVar(&opts.Since, "since", "", "Only include threads updated at or after this RFC3339 timestamp")
 	cmd.PersistentFlags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in 'owner/repo' format")
 	cmd.PersistentFlags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 
@@ -59,7 +61,9 @@ type threadsListOptions struct {
 	UnresolvedOnly bool
 	MineOnly       bool
 	Author         string
+	Since          string
 }
+
 
 func runThreadsList(cmd *cobra.Command, opts *threadsListOptions) error {
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
@@ -73,12 +77,22 @@ func runThreadsList(cmd *cobra.Command, opts *threadsListOptions) error {
 		return err
 	}
 
-	service := threads.NewService(apiClientFactory(identity.Host))
-	payload, err := service.List(identity, threads.ListOptions{
+	listOpts := threads.ListOptions{
 		OnlyUnresolved: opts.UnresolvedOnly,
 		MineOnly:       opts.MineOnly,
 		Author:         strings.TrimSpace(opts.Author),
-	})
+	}
+
+	if opts.Since != "" {
+		t, err := time.Parse(time.RFC3339, opts.Since)
+		if err != nil {
+			return fmt.Errorf("--since: invalid RFC3339 timestamp %q: %w", opts.Since, err)
+		}
+		listOpts.Since = t
+	}
+
+	service := threads.NewService(apiClientFactory(identity.Host))
+	payload, err := service.List(identity, listOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/threads.go
+++ b/cmd/threads.go
@@ -254,11 +254,13 @@ type threadsResolveAllOptions struct {
 }
 
 func runThreadsResolveAll(cmd *cobra.Command, opts *threadsResolveAllOptions) error {
+	inferPR(opts.Selector, &opts.Pull)
 	selector, err := resolver.NormalizeSelector(opts.Selector, opts.Pull)
 	if err != nil {
 		return err
 	}
 
+	inferRepo(&opts.Repo)
 	hostEnv := os.Getenv("GH_HOST")
 	identity, err := resolver.Resolve(selector, opts.Repo, hostEnv)
 	if err != nil {

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -228,3 +228,70 @@ func TestThreadsResolveRequiresThreadID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--thread-id is required")
 }
+
+// ─── F2: resolve-all command test ─────────────────────────────────────────────
+
+func TestThreadsResolveAllCommand(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	fake := &commandFakeAPI{}
+	fake.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		switch path {
+		case "repos/octo/demo":
+			return assignJSON(result, map[string]interface{}{"full_name": "octo/demo"})
+		case "repos/octo/demo/pulls/3":
+			return assignJSON(result, map[string]interface{}{"node_id": "PR_bulk"})
+		default:
+			return errors.New("unexpected path: " + path)
+		}
+	}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		switch {
+		case strings.Contains(query, "reviewThreads"):
+			return assignJSON(result, map[string]interface{}{
+				"node": map[string]interface{}{
+					"reviewThreads": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{
+								"id": "TBulk1", "isResolved": false, "isOutdated": false, "path": "x.go",
+								"viewerCanResolve": true, "viewerCanUnresolve": false,
+								"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+									{"viewerDidAuthor": false, "updatedAt": ts.Format(time.RFC3339), "databaseId": 5},
+								}},
+							},
+						},
+						"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+					},
+				},
+			})
+		case strings.Contains(query, "resolveReviewThread"):
+			return assignJSON(result, map[string]interface{}{
+				"resolveReviewThread": map[string]interface{}{
+					"thread": map[string]interface{}{"id": "TBulk1", "isResolved": true},
+				},
+			})
+		default:
+			return errors.New("unexpected query")
+		}
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	root.SetArgs([]string{"threads", "resolve-all", "--repo", "octo/demo", "3"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Empty(t, stderr.String())
+
+	var payload []map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	require.Len(t, payload, 1)
+	assert.Equal(t, "TBulk1", payload[0]["thread_node_id"])
+	assert.Equal(t, true, payload[0]["is_resolved"])
+}

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -274,22 +275,22 @@ func TestThreadsResolveAllCommand(t *testing.T) {
 					},
 				},
 			})
-			case strings.Contains(query, "ThreadDetails"):
-				threadID, _ := variables["id"].(string)
-				return assignJSON(result, map[string]interface{}{
-					"node": map[string]interface{}{
-						"id": threadID, "isResolved": false,
-						"viewerCanResolve": true, "viewerCanUnresolve": false,
-						"comments": map[string]interface{}{
-							"nodes": []map[string]interface{}{
-								{"id": "C_bulk_first"},
-							},
+		case strings.Contains(query, "ThreadDetails"):
+			threadID, _ := variables["id"].(string)
+			return assignJSON(result, map[string]interface{}{
+				"node": map[string]interface{}{
+					"id": threadID, "isResolved": false,
+					"viewerCanResolve": true, "viewerCanUnresolve": false,
+					"comments": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{"id": "C_bulk_first"},
 						},
 					},
-				})
-			case strings.Contains(query, "addPullRequestReviewThreadReply"):
-				return nil
-			case strings.Contains(query, "resolveReviewThread"):
+				},
+			})
+		case strings.Contains(query, "addPullRequestReviewThreadReply"):
+			return nil
+		case strings.Contains(query, "resolveReviewThread"):
 			return assignJSON(result, map[string]interface{}{
 				"resolveReviewThread": map[string]interface{}{
 					"thread": map[string]interface{}{"id": "TBulk1", "isResolved": true},
@@ -401,6 +402,32 @@ func TestResolveCommitRefFullSHA(t *testing.T) {
 	got, err := resolveCommitRef(sha)
 	require.NoError(t, err)
 	assert.Equal(t, sha, got)
+}
+
+func TestResolveCommitRefResolvesSymbolicRefs(t *testing.T) {
+	branchOut, err := exec.Command("git", "branch", "--show-current").Output()
+	if err != nil {
+		t.Skipf("git branch lookup unavailable: %v", err)
+	}
+
+	refs := []string{"HEAD", strings.TrimSpace(string(branchOut))}
+	tests := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if strings.TrimSpace(ref) != "" {
+			tests = append(tests, ref)
+		}
+	}
+	for _, ref := range tests {
+		ref := ref
+		t.Run(ref, func(t *testing.T) {
+			wantOut, err := exec.Command("git", "rev-parse", "--verify", "--short", "--end-of-options", ref+"^{commit}").Output()
+			require.NoError(t, err)
+
+			got, err := resolveCommitRef(ref)
+			require.NoError(t, err)
+			assert.Equal(t, strings.TrimSpace(string(wantOut)), got)
+		})
+	}
 }
 
 func TestResolveCommandWithHexSHACommit(t *testing.T) {

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -305,3 +305,60 @@ func TestThreadsListSinceInvalidTimestamp(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--since")
 }
+
+func TestThreadsListOutputIDs(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	fake := &commandFakeAPI{}
+	fake.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		switch path {
+		case "repos/octo/demo":
+			return assignJSON(result, map[string]interface{}{"full_name": "octo/demo"})
+		case "repos/octo/demo/pulls/5":
+			return assignJSON(result, map[string]interface{}{"node_id": "PR_node"})
+		default:
+			return errors.New("unexpected path: " + path)
+		}
+	}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		return assignJSON(result, map[string]interface{}{
+			"node": map[string]interface{}{
+				"reviewThreads": map[string]interface{}{
+					"nodes": []map[string]interface{}{
+						{
+							"id": "T_alpha", "isResolved": false, "isOutdated": false, "path": "a.go",
+							"viewerCanResolve": true, "viewerCanUnresolve": false,
+							"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+								{"viewerDidAuthor": false, "updatedAt": "2026-01-01T00:00:00Z", "databaseId": 1},
+							}},
+						},
+						{
+							"id": "T_beta", "isResolved": false, "isOutdated": false, "path": "b.go",
+							"viewerCanResolve": true, "viewerCanUnresolve": false,
+							"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+								{"viewerDidAuthor": false, "updatedAt": "2025-01-01T00:00:00Z", "databaseId": 2},
+							}},
+						},
+					},
+					"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+				},
+			},
+		})
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"threads", "list", "-o", "ids", "--repo", "octo/demo", "5"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "T_alpha", lines[0])
+	assert.Equal(t, "T_beta", lines[1])
+}

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -266,7 +266,15 @@ func TestThreadsResolveAllCommand(t *testing.T) {
 					},
 				},
 			})
-		case strings.Contains(query, "resolveReviewThread"):
+			case strings.Contains(query, "ThreadDetails"):
+				threadID, _ := variables["id"].(string)
+				return assignJSON(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"id": threadID, "isResolved": false,
+						"viewerCanResolve": true, "viewerCanUnresolve": false,
+					},
+				})
+			case strings.Contains(query, "resolveReviewThread"):
 			return assignJSON(result, map[string]interface{}{
 				"resolveReviewThread": map[string]interface{}{
 					"thread": map[string]interface{}{"id": "TBulk1", "isResolved": true},

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -118,9 +118,16 @@ func TestThreadsResolveCommandByThreadID(t *testing.T) {
 					"isResolved":         false,
 					"viewerCanResolve":   true,
 					"viewerCanUnresolve": true,
+					"comments": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{"id": "C_first"},
+						},
+					},
 				},
 			}
 			return assignJSON(result, payload)
+		case strings.Contains(query, "addPullRequestReviewThreadReply"):
+			return nil
 		case strings.Contains(query, "resolveReviewThread"):
 			payload := map[string]interface{}{
 				"resolveReviewThread": map[string]interface{}{
@@ -142,7 +149,7 @@ func TestThreadsResolveCommandByThreadID(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	root.SetOut(stdout)
 	root.SetErr(stderr)
-	root.SetArgs([]string{"threads", "resolve", "--thread-id", "T_thread", "--repo", "octo/demo", "9"})
+	root.SetArgs([]string{"threads", "resolve", "--thread-id", "T_thread", "--commit", "abc1234", "--repo", "octo/demo", "9"})
 
 	err := root.Execute()
 	require.NoError(t, err)
@@ -152,6 +159,7 @@ func TestThreadsResolveCommandByThreadID(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	assert.Equal(t, "T_thread", payload["thread_node_id"])
 	assert.Equal(t, true, payload["is_resolved"])
+	assert.Contains(t, payload["reply_body"], "abc1234")
 }
 
 func TestThreadsUnresolveCommandByThreadID(t *testing.T) {
@@ -272,8 +280,15 @@ func TestThreadsResolveAllCommand(t *testing.T) {
 					"node": map[string]interface{}{
 						"id": threadID, "isResolved": false,
 						"viewerCanResolve": true, "viewerCanUnresolve": false,
+						"comments": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{"id": "C_bulk_first"},
+							},
+						},
 					},
 				})
+			case strings.Contains(query, "addPullRequestReviewThreadReply"):
+				return nil
 			case strings.Contains(query, "resolveReviewThread"):
 			return assignJSON(result, map[string]interface{}{
 				"resolveReviewThread": map[string]interface{}{
@@ -291,7 +306,7 @@ func TestThreadsResolveAllCommand(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	root.SetOut(stdout)
 	root.SetErr(stderr)
-	root.SetArgs([]string{"threads", "resolve-all", "--repo", "octo/demo", "3"})
+	root.SetArgs([]string{"threads", "resolve-all", "--repo", "octo/demo", "--commit", "def5678", "3"})
 
 	err := root.Execute()
 	require.NoError(t, err)
@@ -441,4 +456,102 @@ func TestResolveCommandWithHexSHACommit(t *testing.T) {
 	assert.Equal(t, "T_sha", payload["thread_node_id"])
 	assert.Equal(t, true, payload["is_resolved"])
 	assert.Contains(t, payload["reply_body"], "abc1234")
+}
+
+// ─── Validation gate tests ──────────────────────────────────────────────────
+
+func TestResolveRejectsWithoutCommitOrThumbsDown(t *testing.T) {
+	root := newRootCommand()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"threads", "resolve", "--thread-id", "T_thread", "--repo", "octo/demo", "9"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must provide --commit")
+}
+
+func TestResolveAcceptsThumbsDownWithoutCommit(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	var reactCalled bool
+	var reactContent string
+	fake := &commandFakeAPI{}
+	fake.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		return errors.New("unexpected REST call")
+	}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		switch {
+		case strings.Contains(query, "ThreadDetails"):
+			return assignJSON(result, map[string]interface{}{
+				"node": map[string]interface{}{
+					"id": "T_td", "isResolved": false,
+					"viewerCanResolve": true, "viewerCanUnresolve": false,
+					"comments": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{"id": "C_td_first"},
+						},
+					},
+				},
+			})
+		case strings.Contains(query, "addPullRequestReviewThreadReply"):
+			return nil
+		case strings.Contains(query, "resolveReviewThread"):
+			return assignJSON(result, map[string]interface{}{
+				"resolveReviewThread": map[string]interface{}{
+					"thread": map[string]interface{}{"id": "T_td", "isResolved": true},
+				},
+			})
+		case strings.Contains(query, "addReaction"):
+			reactCalled = true
+			if c, ok := variables["content"].(string); ok {
+				reactContent = c
+			}
+			return nil
+		default:
+			return errors.New("unexpected query")
+		}
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"threads", "resolve", "--thread-id", "T_td", "--react", "thumbs_down", "--message", "not a bug", "--repo", "octo/demo", "9"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	assert.True(t, reactCalled, "addReaction should have been called")
+	assert.Equal(t, "THUMBS_DOWN", reactContent)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, "T_td", payload["thread_node_id"])
+	assert.Equal(t, true, payload["is_resolved"])
+	assert.Equal(t, "THUMBS_DOWN", payload["reaction"])
+}
+
+func TestResolveRejectsInvalidReaction(t *testing.T) {
+	root := newRootCommand()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"threads", "resolve", "--thread-id", "T_thread", "--react", "invalid", "--repo", "octo/demo", "9"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--react: invalid reaction")
+}
+
+func TestResolveAllRejectsWithoutCommit(t *testing.T) {
+	root := newRootCommand()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"threads", "resolve-all", "--repo", "octo/demo", "3"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--commit is required for resolve-all")
 }

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -362,3 +362,75 @@ func TestThreadsListOutputIDs(t *testing.T) {
 	assert.Equal(t, "T_alpha", lines[0])
 	assert.Equal(t, "T_beta", lines[1])
 }
+
+// F6: resolveCommitRef unit tests
+
+func TestResolveCommitRefPassthroughHexSHA(t *testing.T) {
+	// A valid hex SHA should be returned unchanged without calling git.
+	sha := "abc1234"
+	got, err := resolveCommitRef(sha)
+	require.NoError(t, err)
+	assert.Equal(t, sha, got)
+}
+
+func TestResolveCommitRefFullSHA(t *testing.T) {
+	sha := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	got, err := resolveCommitRef(sha)
+	require.NoError(t, err)
+	assert.Equal(t, sha, got)
+}
+
+func TestResolveCommandWithHexSHACommit(t *testing.T) {
+	originalFactory := apiClientFactory
+	defer func() { apiClientFactory = originalFactory }()
+
+	var capturedBody string
+	fake := &commandFakeAPI{}
+	fake.restFunc = func(method, path string, params map[string]string, body interface{}, result interface{}) error {
+		return errors.New("unexpected REST call")
+	}
+	fake.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		switch {
+		case strings.Contains(query, "ThreadDetails"):
+			return assignJSON(result, map[string]interface{}{
+				"node": map[string]interface{}{
+					"id":                 "T_sha",
+					"isResolved":         false,
+					"viewerCanResolve":   true,
+					"viewerCanUnresolve": false,
+				},
+			})
+		case strings.Contains(query, "addPullRequestReviewThreadReply"):
+			if b, ok := variables["body"].(string); ok {
+				capturedBody = b
+			}
+			return nil
+		case strings.Contains(query, "resolveReviewThread"):
+			return assignJSON(result, map[string]interface{}{
+				"resolveReviewThread": map[string]interface{}{
+					"thread": map[string]interface{}{"id": "T_sha", "isResolved": true},
+				},
+			})
+		default:
+			return errors.New("unexpected query")
+		}
+	}
+	apiClientFactory = func(host string) ghcli.API { return fake }
+
+	root := newRootCommand()
+	stdout := &bytes.Buffer{}
+	root.SetOut(stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"threads", "resolve", "--thread-id", "T_sha", "--commit", "abc1234", "--repo", "octo/demo", "9"})
+
+	err := root.Execute()
+	require.NoError(t, err)
+
+	assert.Contains(t, capturedBody, "abc1234")
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, "T_sha", payload["thread_node_id"])
+	assert.Equal(t, true, payload["is_resolved"])
+	assert.Contains(t, payload["reply_body"], "abc1234")
+}

--- a/cmd/threads_test.go
+++ b/cmd/threads_test.go
@@ -295,3 +295,13 @@ func TestThreadsResolveAllCommand(t *testing.T) {
 	assert.Equal(t, "TBulk1", payload[0]["thread_node_id"])
 	assert.Equal(t, true, payload[0]["is_resolved"])
 }
+
+func TestThreadsListSinceInvalidTimestamp(t *testing.T) {
+	root := newRootCommand()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"threads", "list", "--repo", "octo/demo", "--since", "not-a-timestamp", "5"})
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--since")
+}

--- a/internal/ghcli/ghcli.go
+++ b/internal/ghcli/ghcli.go
@@ -210,6 +210,40 @@ func (c *Client) GraphQL(query string, variables map[string]interface{}, result 
 	return nil
 }
 
+// CurrentRepo returns the "owner/repo" for the current working directory
+// by delegating to `gh repo view`. This respects `gh repo set-default`
+// and the git remote configuration.
+func CurrentRepo() (string, error) {
+	stdout, stderr, err := runGh([]string{"repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"}, nil)
+	if err != nil {
+		return "", wrapError(err, stdout, stderr)
+	}
+	result := strings.TrimSpace(string(stdout))
+	if result == "" {
+		return "", fmt.Errorf("gh repo view returned empty nameWithOwner")
+	}
+	return result, nil
+}
+
+// CurrentPR returns the pull request number for the current branch
+// by delegating to `gh pr view`. Returns 0 and an error if the current
+// branch has no associated pull request.
+func CurrentPR() (int, error) {
+	stdout, stderr, err := runGh([]string{"pr", "view", "--json", "number", "-q", ".number"}, nil)
+	if err != nil {
+		return 0, wrapError(err, stdout, stderr)
+	}
+	result := strings.TrimSpace(string(stdout))
+	if result == "" {
+		return 0, fmt.Errorf("gh pr view returned empty number")
+	}
+	n, err := strconv.Atoi(result)
+	if err != nil {
+		return 0, fmt.Errorf("gh pr view returned non-numeric number: %q", result)
+	}
+	return n, nil
+}
+
 // runGh executes the `gh` CLI command with provided arguments and optional stdin data.
 func runGh(args []string, stdin []byte) ([]byte, string, error) {
 	cmd := exec.Command("gh", args...)

--- a/internal/reactions/reactions.go
+++ b/internal/reactions/reactions.go
@@ -1,0 +1,70 @@
+package reactions
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/agynio/gh-pr-review/internal/ghcli"
+)
+
+const addReactionMutation = `
+mutation AddReaction($subjectId: ID!, $content: ReactionContent!) {
+  addReaction(input: {subjectId: $subjectId, content: $content}) {
+    reaction {
+      content
+    }
+  }
+}
+`
+
+// ValidReactions maps CLI-friendly reaction names to GitHub GraphQL ReactionContent enum values.
+var ValidReactions = map[string]string{
+	"thumbs_up":   "THUMBS_UP",
+	"thumbs_down": "THUMBS_DOWN",
+	"laugh":       "LAUGH",
+	"hooray":      "HOORAY",
+	"confused":    "CONFUSED",
+	"heart":       "HEART",
+	"rocket":      "ROCKET",
+	"eyes":        "EYES",
+}
+
+// ValidReactionNames returns a sorted list of valid reaction names for display.
+func ValidReactionNames() []string {
+	names := make([]string, 0, len(ValidReactions))
+	for k := range ValidReactions {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Validate checks if the given reaction name is valid and returns an error if not.
+func Validate(reaction string) error {
+	if _, ok := ValidReactions[reaction]; !ok {
+		return fmt.Errorf("invalid reaction %q; valid values: %s", reaction, strings.Join(ValidReactionNames(), ", "))
+	}
+	return nil
+}
+
+// React adds a reaction to any reactable GitHub node.
+// React adds a reaction to any reactable GitHub node.
+// The reaction parameter accepts CLI-friendly names (e.g. "thumbs_up").
+func React(api ghcli.API, subjectID, reaction string) error {
+	graphqlContent, ok := ValidReactions[reaction]
+	if !ok {
+		return fmt.Errorf("invalid reaction %q", reaction)
+	}
+	return ReactRaw(api, subjectID, graphqlContent)
+}
+
+// ReactRaw adds a reaction using the raw GraphQL ReactionContent enum value
+// (e.g. "THUMBS_UP"). Use this when the caller has already mapped the value.
+func ReactRaw(api ghcli.API, subjectID, graphqlContent string) error {
+	variables := map[string]interface{}{
+		"subjectId": subjectID,
+		"content":   graphqlContent,
+	}
+	return api.GraphQL(addReactionMutation, variables, nil)
+}

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -56,12 +56,29 @@ func BuildReport(reviews []Review, threads []Thread, filters FilterOptions) Repo
 		return Report{Reviews: []ReportReview{}}
 	}
 
+	var authorFilter string
+	if filters.Author != "" {
+		authorFilter = strings.ToLower(filters.Author)
+	}
+
 	for _, thread := range threads {
-		if filters.RequireUnresolved && thread.IsResolved {
+		if !filters.IncludeResolved && filters.RequireUnresolved && thread.IsResolved {
 			continue
 		}
 		if filters.RequireNotOutdated && thread.IsOutdated {
 			continue
+		}
+		if authorFilter != "" {
+			matched := false
+			for _, comment := range thread.Comments {
+				if strings.ToLower(comment.AuthorLogin) == authorFilter {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
 		}
 
 		var parent *ThreadComment

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -71,7 +71,7 @@ func BuildReport(reviews []Review, threads []Thread, filters FilterOptions) Repo
 		if authorFilter != "" {
 			matched := false
 			for _, comment := range thread.Comments {
-				if strings.ToLower(comment.AuthorLogin) == authorFilter {
+				if strings.Contains(strings.ToLower(comment.AuthorLogin), authorFilter) {
 					matched = true
 					break
 				}

--- a/internal/report/builder_test.go
+++ b/internal/report/builder_test.go
@@ -310,6 +310,29 @@ func TestBuildReportAuthorFilterIsCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestBuildReportAuthorFilterMatchesSubstring(t *testing.T) {
+	reviews := []report.Review{
+		{ID: "R1", State: report.StateCommented, AuthorLogin: "CodeRabbitAI", DatabaseID: 1},
+	}
+	threads := []report.Thread{
+		{
+			ID: "T1", IsResolved: false,
+			Comments: []report.ThreadComment{
+				{NodeID: "C1", DatabaseID: 101, Body: "found a bug", AuthorLogin: "chatgpt-codex-connector", CreatedAt: time.Now(), ReviewDatabaseID: intPtr(1)},
+			},
+		},
+	}
+
+	result := report.BuildReport(reviews, threads, report.FilterOptions{Author: "codex"})
+	totalComments := 0
+	for _, r := range result.Reviews {
+		totalComments += len(r.Comments)
+	}
+	if totalComments != 1 {
+		t.Fatalf("expected 1 thread with substring author match, got %d", totalComments)
+	}
+}
+
 // ─── Tests for --all (IncludeResolved) ──────────────────────────────────────
 
 func TestBuildReportIncludeResolvedShowsResolvedThreads(t *testing.T) {

--- a/internal/report/builder_test.go
+++ b/internal/report/builder_test.go
@@ -255,3 +255,99 @@ func mustFindComment(comments []report.ReportComment, threadID string) report.Re
 func strPtr(v string) *string {
 	return &v
 }
+
+// ─── Tests for --author filter ──────────────────────────────────────────────
+
+func TestBuildReportAuthorFilterIncludesMatchingThreads(t *testing.T) {
+	reviews := []report.Review{
+		{ID: "R1", State: report.StateCommented, AuthorLogin: "coderabbitai", DatabaseID: 1},
+	}
+	threads := []report.Thread{
+		{
+			ID: "T1", IsResolved: false,
+			Comments: []report.ThreadComment{
+				{NodeID: "C1", DatabaseID: 101, Body: "rabbit comment", AuthorLogin: "coderabbitai", CreatedAt: time.Now(), ReviewDatabaseID: intPtr(1)},
+			},
+		},
+		{
+			ID: "T2", IsResolved: false,
+			Comments: []report.ThreadComment{
+				{NodeID: "C2", DatabaseID: 102, Body: "codex comment", AuthorLogin: "chatgpt-codex-connector", CreatedAt: time.Now(), ReviewDatabaseID: intPtr(1)},
+			},
+		},
+	}
+
+	result := report.BuildReport(reviews, threads, report.FilterOptions{Author: "chatgpt-codex-connector"})
+	totalComments := 0
+	for _, r := range result.Reviews {
+		totalComments += len(r.Comments)
+	}
+	if totalComments != 1 {
+		t.Errorf("expected 1 thread with matching author, got %d", totalComments)
+	}
+}
+
+func TestBuildReportAuthorFilterIsCaseInsensitive(t *testing.T) {
+	reviews := []report.Review{
+		{ID: "R1", State: report.StateCommented, AuthorLogin: "CodeRabbitAI", DatabaseID: 1},
+	}
+	threads := []report.Thread{
+		{
+			ID: "T1", IsResolved: false,
+			Comments: []report.ThreadComment{
+				{NodeID: "C1", DatabaseID: 101, Body: "found a bug", AuthorLogin: "CodeRabbitAI", CreatedAt: time.Now(), ReviewDatabaseID: intPtr(1)},
+			},
+		},
+	}
+
+	result := report.BuildReport(reviews, threads, report.FilterOptions{Author: "coderabbitai"})
+	totalComments := 0
+	for _, r := range result.Reviews {
+		totalComments += len(r.Comments)
+	}
+	if totalComments != 1 {
+		t.Errorf("expected 1 thread (case-insensitive match), got %d", totalComments)
+	}
+}
+
+// ─── Tests for --all (IncludeResolved) ──────────────────────────────────────
+
+func TestBuildReportIncludeResolvedShowsResolvedThreads(t *testing.T) {
+	reviews := []report.Review{
+		{ID: "R1", State: report.StateCommented, AuthorLogin: "alice", DatabaseID: 1},
+	}
+	threads := []report.Thread{
+		{
+			ID: "T1", IsResolved: true,
+			Comments: []report.ThreadComment{
+				{NodeID: "C1", DatabaseID: 101, Body: "resolved thread", AuthorLogin: "alice", CreatedAt: time.Now(), ReviewDatabaseID: intPtr(1)},
+			},
+		},
+		{
+			ID: "T2", IsResolved: false,
+			Comments: []report.ThreadComment{
+				{NodeID: "C2", DatabaseID: 102, Body: "open thread", AuthorLogin: "alice", CreatedAt: time.Now(), ReviewDatabaseID: intPtr(1)},
+			},
+		},
+	}
+
+	// RequireUnresolved only → should get 1 (T2)
+	result := report.BuildReport(reviews, threads, report.FilterOptions{RequireUnresolved: true})
+	c1 := 0
+	for _, r := range result.Reviews {
+		c1 += len(r.Comments)
+	}
+	if c1 != 1 {
+		t.Errorf("RequireUnresolved: expected 1 thread, got %d", c1)
+	}
+
+	// RequireUnresolved + IncludeResolved → should get 2 (both)
+	result2 := report.BuildReport(reviews, threads, report.FilterOptions{RequireUnresolved: true, IncludeResolved: true})
+	c2 := 0
+	for _, r := range result2.Reviews {
+		c2 += len(r.Comments)
+	}
+	if c2 != 2 {
+		t.Errorf("IncludeResolved override: expected 2 threads, got %d", c2)
+	}
+}

--- a/internal/report/domain.go
+++ b/internal/report/domain.go
@@ -20,6 +20,8 @@ type FilterOptions struct {
 	RequireNotOutdated   bool
 	TailReplies          int
 	IncludeCommentNodeID bool
+	Author               string
+	IncludeResolved      bool
 }
 
 // Review models a pull request review fetched from GraphQL.

--- a/internal/report/service.go
+++ b/internal/report/service.go
@@ -30,6 +30,8 @@ type Options struct {
 	RequireNotOutdated   bool
 	TailReplies          int
 	IncludeCommentNodeID bool
+	Author               string
+	IncludeResolved      bool
 }
 
 // NewService constructs a report service using the provided GraphQL API client.
@@ -201,6 +203,8 @@ func (s *Service) Fetch(pr resolver.Identity, opts Options) (Report, error) {
 		RequireNotOutdated:   opts.RequireNotOutdated,
 		TailReplies:          opts.TailReplies,
 		IncludeCommentNodeID: opts.IncludeCommentNodeID,
+		Author:               opts.Author,
+		IncludeResolved:      opts.IncludeResolved,
 	}
 
 	return BuildReport(reviews, threads, filters), nil

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -59,6 +59,36 @@ type ActionResult struct {
 	IsResolved   bool   `json:"is_resolved"`
 }
 
+
+// ResolveAllOptions configures bulk resolution.
+type ResolveAllOptions struct {
+	Author     string // only resolve threads started by this author
+	Commit     string // attach commit link to each resolution
+	Unresolved bool   // only resolve currently-unresolved threads (default true)
+}
+
+// ResolveAll resolves all matching threads for the given pull request.
+func (s *Service) ResolveAll(pr resolver.Identity, opts ResolveAllOptions) ([]ActionResult, error) {
+	listOpts := ListOptions{
+		OnlyUnresolved: opts.Unresolved,
+		Author:         opts.Author,
+	}
+	ts, err := s.List(pr, listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]ActionResult, 0, len(ts))
+	for _, t := range ts {
+		res, err := s.performResolve(t.ThreadID, strings.TrimSpace(opts.Commit), pr.Owner, pr.Repo)
+		if err != nil {
+			results = append(results, ActionResult{ThreadNodeID: t.ThreadID, IsResolved: false})
+			continue
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}
 type pullContext struct {
 	identity resolver.Identity
 	nodeID   string

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -30,13 +30,21 @@ type ListOptions struct {
 
 // Thread represents a normalized review thread payload for JSON output.
 type Thread struct {
-	ThreadID   string     `json:"threadId"`
-	IsResolved bool       `json:"isResolved"`
-	ResolvedBy *string    `json:"resolvedBy,omitempty"`
-	UpdatedAt  *time.Time `json:"updatedAt,omitempty"`
-	Path       string     `json:"path"`
-	Line       *int       `json:"line,omitempty"`
-	IsOutdated bool       `json:"isOutdated"`
+	ThreadID   string          `json:"threadId"`
+	IsResolved bool            `json:"isResolved"`
+	ResolvedBy *string         `json:"resolvedBy,omitempty"`
+	UpdatedAt  *time.Time      `json:"updatedAt,omitempty"`
+	Path       string          `json:"path"`
+	Line       *int            `json:"line,omitempty"`
+	IsOutdated bool            `json:"isOutdated"`
+	Comments   []ThreadComment `json:"comments,omitempty"`
+}
+
+// ThreadComment represents a single comment in a thread for JSON output.
+type ThreadComment struct {
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"createdAt"`
 }
 
 // ActionOptions controls resolve/unresolve operations.
@@ -123,6 +131,20 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 			linePtr = &value
 		}
 
+		// Map comments for output
+		var comments []ThreadComment
+		for _, c := range node.Comments.Nodes {
+			author := ""
+			if c.Author != nil {
+				author = c.Author.Login
+			}
+			comments = append(comments, ThreadComment{
+				Author:    author,
+				Body:      c.Body,
+				CreatedAt: c.UpdatedAt.UTC().Format(time.RFC3339),
+			})
+		}
+
 		allThreads = append(allThreads, Thread{
 			ThreadID:   node.ID,
 			IsResolved: node.IsResolved,
@@ -131,6 +153,7 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 			Path:       node.Path,
 			Line:       linePtr,
 			IsOutdated: node.IsOutdated,
+			Comments:   comments,
 		})
 	}
 
@@ -191,9 +214,10 @@ type threadNode struct {
 	} `json:"resolvedBy"`
 	Comments struct {
 		Nodes []struct {
-			ViewerDidAuthor bool      `json:"viewerDidAuthor"`
-			UpdatedAt       time.Time `json:"updatedAt"`
-			DatabaseID      int64     `json:"databaseId"`
+						ViewerDidAuthor bool      `json:"viewerDidAuthor"`
+						UpdatedAt       time.Time `json:"updatedAt"`
+						DatabaseID      int64     `json:"databaseId"`
+						Body            string    `json:"body"`
 			Author          *struct {
 				Login string `json:"login"`
 			} `json:"author"`
@@ -397,6 +421,7 @@ query Threads($id: ID!, $after: String) {
               databaseId
               viewerDidAuthor
               updatedAt
+              body
               author { login }
             }
           }

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -308,7 +308,7 @@ func (s *Service) changeResolution(pr resolver.Identity, opts ActionOptions, res
 	}
 
 	if resolve {
-		return s.performResolve(threadID, strings.TrimSpace(opts.Commit))
+		return s.performResolve(threadID, strings.TrimSpace(opts.Commit), pr.Owner, pr.Repo)
 	}
 	return s.performUnresolve(threadID)
 }
@@ -334,9 +334,10 @@ type threadDetails struct {
 	ViewerCanUnresolve bool   `json:"viewerCanUnresolve"`
 }
 
-func (s *Service) performResolve(threadID, commit string) (ActionResult, error) {
+func (s *Service) performResolve(threadID, commit, owner, repo string) (ActionResult, error) {
 	if commit != "" {
-		body := fmt.Sprintf("Addressed in `%s`", commit)
+		commitURL := fmt.Sprintf("https://github.com/%s/%s/commit/%s", owner, repo, commit)
+		body := fmt.Sprintf("Addressed in [`%s`](%s)", commit, commitURL)
 		replyVars := map[string]interface{}{
 			"threadId": threadID,
 			"body":     body,

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -183,7 +183,7 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 			comments = append(comments, ThreadComment{
 				Author:    author,
 				Body:      c.Body,
-				CreatedAt: c.UpdatedAt.UTC().Format(time.RFC3339), // GraphQL returns updatedAt; used as best proxy for comment time
+				CreatedAt: c.CreatedAt.UTC().Format(time.RFC3339),
 			})
 		}
 
@@ -256,10 +256,11 @@ type threadNode struct {
 	} `json:"resolvedBy"`
 	Comments struct {
 		Nodes []struct {
-						ViewerDidAuthor bool      `json:"viewerDidAuthor"`
-						UpdatedAt       time.Time `json:"updatedAt"`
-						DatabaseID      int64     `json:"databaseId"`
-						Body            string    `json:"body"`
+			ViewerDidAuthor bool      `json:"viewerDidAuthor"`
+			CreatedAt       time.Time `json:"createdAt"`
+			UpdatedAt       time.Time `json:"updatedAt"`
+			DatabaseID      int64     `json:"databaseId"`
+			Body            string    `json:"body"`
 			Author          *struct {
 				Login string `json:"login"`
 			} `json:"author"`
@@ -467,6 +468,7 @@ query Threads($id: ID!, $after: String) {
             nodes {
               databaseId
               viewerDidAuthor
+              createdAt
               updatedAt
               body
               author { login }

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/agynio/gh-pr-review/internal/ghcli"
+	"github.com/agynio/gh-pr-review/internal/reactions"
 	"github.com/agynio/gh-pr-review/internal/resolver"
 )
 
@@ -578,33 +579,11 @@ mutation AddThreadReply($threadId: ID!, $body: String!) {
   }
 }
 `
-const addReactionMutation = `
-mutation AddReaction($subjectId: ID!, $content: ReactionContent!) {
-  addReaction(input: {subjectId: $subjectId, content: $content}) {
-    reaction {
-      content
-    }
-  }
-}
-`
-
-// ValidReactions maps CLI-friendly reaction names to GitHub GraphQL ReactionContent enum values.
-var ValidReactions = map[string]string{
-	"thumbs_up":   "THUMBS_UP",
-	"thumbs_down": "THUMBS_DOWN",
-	"laugh":       "LAUGH",
-	"hooray":      "HOORAY",
-	"confused":    "CONFUSED",
-	"heart":       "HEART",
-	"rocket":      "ROCKET",
-	"eyes":        "EYES",
-}
+// ValidReactions delegates to the reactions package for backward compatibility.
+var ValidReactions = reactions.ValidReactions
 
 // React adds a reaction to a comment identified by its node ID.
+// Delegates to the reactions package.
 func (s *Service) React(commentID, reaction string) error {
-	variables := map[string]interface{}{
-		"subjectId": commentID,
-		"content":   reaction,
-	}
-	return s.API.GraphQL(addReactionMutation, variables, nil)
+	return reactions.ReactRaw(s.API, commentID, reaction)
 }

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -58,6 +58,7 @@ type ActionOptions struct {
 type ActionResult struct {
 	ThreadNodeID string `json:"thread_node_id"`
 	IsResolved   bool   `json:"is_resolved"`
+	ReplyBody    string `json:"reply_body,omitempty"`
 }
 
 
@@ -396,12 +397,13 @@ type threadDetails struct {
 }
 
 func (s *Service) performResolve(threadID, commit, owner, repo string) (ActionResult, error) {
+	var replyBody string
 	if commit != "" {
 		commitURL := fmt.Sprintf("https://github.com/%s/%s/commit/%s", owner, repo, commit)
-		body := fmt.Sprintf("Addressed in [`%s`](%s)", commit, commitURL)
+		replyBody = fmt.Sprintf("Addressed in [`%s`](%s)", commit, commitURL)
 		replyVars := map[string]interface{}{
 			"threadId": threadID,
-			"body":     body,
+			"body":     replyBody,
 		}
 		if err := s.API.GraphQL(addThreadReplyMutation, replyVars, nil); err != nil {
 			return ActionResult{}, fmt.Errorf("post commit reply: %w", err)
@@ -420,7 +422,7 @@ func (s *Service) performResolve(threadID, commit, owner, repo string) (ActionRe
 	if err := s.API.GraphQL(resolveThreadMutation, variables, &resp); err != nil {
 		return ActionResult{}, fmt.Errorf("resolve thread mutation: %w", err)
 	}
-	return ActionResult{ThreadNodeID: resp.Resolve.Thread.ID, IsResolved: resp.Resolve.Thread.IsResolved}, nil
+	return ActionResult{ThreadNodeID: resp.Resolve.Thread.ID, IsResolved: resp.Resolve.Thread.IsResolved, ReplyBody: replyBody}, nil
 }
 
 func (s *Service) performUnresolve(threadID string) (ActionResult, error) {

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -356,7 +356,7 @@ func (s *Service) performResolve(threadID, commit string) (ActionResult, error) 
 		} `json:"resolveReviewThread"`
 	}
 	if err := s.API.GraphQL(resolveThreadMutation, variables, &resp); err != nil {
-		return ActionResult{}, err
+		return ActionResult{}, fmt.Errorf("resolve thread mutation: %w", err)
 	}
 	return ActionResult{ThreadNodeID: resp.Resolve.Thread.ID, IsResolved: resp.Resolve.Thread.IsResolved}, nil
 }
@@ -372,7 +372,7 @@ func (s *Service) performUnresolve(threadID string) (ActionResult, error) {
 		} `json:"unresolveReviewThread"`
 	}
 	if err := s.API.GraphQL(unresolveThreadMutation, variables, &resp); err != nil {
-		return ActionResult{}, err
+		return ActionResult{}, fmt.Errorf("unresolve thread mutation: %w", err)
 	}
 	return ActionResult{ThreadNodeID: resp.Unresolve.Thread.ID, IsResolved: resp.Unresolve.Thread.IsResolved}, nil
 }

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -66,7 +66,6 @@ type ActionResult struct {
 	Error        string `json:"error,omitempty"`
 }
 
-
 // ResolveAllOptions configures bulk resolution.
 type ResolveAllOptions struct {
 	Author     string // only resolve threads started by this author
@@ -101,6 +100,7 @@ func (s *Service) ResolveAll(pr resolver.Identity, opts ResolveAllOptions) ([]Ac
 	}
 	return results, nil
 }
+
 type pullContext struct {
 	identity resolver.Identity
 	nodeID   string
@@ -142,7 +142,7 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 				latest = comment.UpdatedAt
 				hasStamp = true
 			}
-				if !authorMatched && comment.Author != nil && strings.Contains(strings.ToLower(comment.Author.Login), authorFilter) {
+			if !authorMatched && comment.Author != nil && strings.Contains(strings.ToLower(comment.Author.Login), authorFilter) {
 				authorMatched = true
 			}
 		}
@@ -159,7 +159,6 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 		if !opts.Since.IsZero() && (!hasStamp || latest.Before(opts.Since)) {
 			continue
 		}
-
 
 		var resolvedBy *string
 		if node.ResolvedBy != nil && node.ResolvedBy.Login != "" {
@@ -362,6 +361,9 @@ func (s *Service) changeResolution(pr resolver.Identity, opts ActionOptions, res
 	if threadID == "" {
 		return ActionResult{}, errors.New("thread id is required")
 	}
+	commit := strings.TrimSpace(opts.Commit)
+	message := strings.TrimSpace(opts.Message)
+	reaction := strings.TrimSpace(opts.React)
 
 	thread, err := s.fetchThread(pr.Host, threadID)
 	if err != nil {
@@ -369,11 +371,12 @@ func (s *Service) changeResolution(pr resolver.Identity, opts ActionOptions, res
 	}
 
 	desired := resolve
-	if thread.IsResolved == desired {
+	alreadyDesired := thread.IsResolved == desired
+	if alreadyDesired && !(resolve && (commit != "" || message != "" || reaction != "")) {
 		return ActionResult{ThreadNodeID: thread.ID, IsResolved: thread.IsResolved}, nil
 	}
 
-	if resolve && !thread.ViewerCanResolve {
+	if resolve && !alreadyDesired && !thread.ViewerCanResolve {
 		return ActionResult{}, errors.New("viewer cannot resolve this thread")
 	}
 	if !resolve && !thread.ViewerCanUnresolve {
@@ -381,18 +384,18 @@ func (s *Service) changeResolution(pr resolver.Identity, opts ActionOptions, res
 	}
 
 	if resolve {
-		result, err := s.performResolve(threadID, strings.TrimSpace(opts.Commit), strings.TrimSpace(opts.Message), pr.Host, pr.Owner, pr.Repo)
+		result, err := s.performResolve(threadID, commit, message, pr.Host, pr.Owner, pr.Repo, !alreadyDesired)
 		if err != nil {
 			return ActionResult{}, err
 		}
 		// Add reaction to first comment if requested
-		if opts.React != "" {
+		if reaction != "" {
 			commentID := thread.FirstCommentID()
 			if commentID != "" {
-				if err := s.React(commentID, opts.React); err != nil {
+				if err := s.React(commentID, reaction); err != nil {
 					return ActionResult{}, fmt.Errorf("add reaction: %w", err)
 				}
-				result.Reaction = opts.React
+				result.Reaction = reaction
 			}
 		}
 		return result, nil
@@ -434,7 +437,7 @@ func (d *threadDetails) FirstCommentID() string {
 	return ""
 }
 
-func (s *Service) performResolve(threadID, commit, message, host, owner, repo string) (ActionResult, error) {
+func (s *Service) performResolve(threadID, commit, message, host, owner, repo string, applyResolution bool) (ActionResult, error) {
 	var replyBody string
 
 	// Post message reply first if provided (e.g. thumbs_down explanation)
@@ -464,6 +467,10 @@ func (s *Service) performResolve(threadID, commit, message, host, owner, repo st
 			return ActionResult{}, fmt.Errorf("post commit reply: %w", err)
 		}
 		replyBody = commitReply
+	}
+
+	if !applyResolution {
+		return ActionResult{ThreadNodeID: threadID, IsResolved: true, ReplyBody: replyBody}, nil
 	}
 
 	variables := map[string]interface{}{"threadId": threadID}
@@ -579,6 +586,7 @@ mutation AddThreadReply($threadId: ID!, $body: String!) {
   }
 }
 `
+
 // ValidReactions delegates to the reactions package for backward compatibility.
 var ValidReactions = reactions.ValidReactions
 

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -52,6 +52,8 @@ type ThreadComment struct {
 type ActionOptions struct {
 	ThreadID string
 	Commit   string
+	React    string // reaction to add to first comment (e.g. "THUMBS_UP")
+	Message  string // optional reply message posted before resolving
 }
 
 // ActionResult captures the outcome of a resolve/unresolve mutation.
@@ -59,6 +61,7 @@ type ActionResult struct {
 	ThreadNodeID string `json:"thread_node_id"`
 	IsResolved   bool   `json:"is_resolved"`
 	ReplyBody    string `json:"reply_body,omitempty"`
+	Reaction     string `json:"reaction,omitempty"`
 	Error        string `json:"error,omitempty"`
 }
 
@@ -67,6 +70,7 @@ type ActionResult struct {
 type ResolveAllOptions struct {
 	Author     string // only resolve threads started by this author
 	Commit     string // attach commit link to each resolution
+	React      string // reaction to add to first comment (GraphQL enum value)
 	Unresolved bool   // only resolve currently-unresolved threads (default true)
 }
 
@@ -86,6 +90,7 @@ func (s *Service) ResolveAll(pr resolver.Identity, opts ResolveAllOptions) ([]Ac
 		res, err := s.changeResolution(pr, ActionOptions{
 			ThreadID: t.ThreadID,
 			Commit:   strings.TrimSpace(opts.Commit),
+			React:    opts.React,
 		}, true)
 		if err != nil {
 			results = append(results, ActionResult{ThreadNodeID: t.ThreadID, IsResolved: false, Error: err.Error()})
@@ -375,7 +380,21 @@ func (s *Service) changeResolution(pr resolver.Identity, opts ActionOptions, res
 	}
 
 	if resolve {
-		return s.performResolve(threadID, strings.TrimSpace(opts.Commit), pr.Host, pr.Owner, pr.Repo)
+		result, err := s.performResolve(threadID, strings.TrimSpace(opts.Commit), strings.TrimSpace(opts.Message), pr.Host, pr.Owner, pr.Repo)
+		if err != nil {
+			return ActionResult{}, err
+		}
+		// Add reaction to first comment if requested
+		if opts.React != "" {
+			commentID := thread.FirstCommentID()
+			if commentID != "" {
+				if err := s.React(commentID, opts.React); err != nil {
+					return ActionResult{}, fmt.Errorf("add reaction: %w", err)
+				}
+				result.Reaction = opts.React
+			}
+		}
+		return result, nil
 	}
 	return s.performUnresolve(threadID)
 }
@@ -399,24 +418,51 @@ type threadDetails struct {
 	IsResolved         bool   `json:"isResolved"`
 	ViewerCanResolve   bool   `json:"viewerCanResolve"`
 	ViewerCanUnresolve bool   `json:"viewerCanUnresolve"`
+	Comments           struct {
+		Nodes []struct {
+			ID string `json:"id"`
+		} `json:"nodes"`
+	} `json:"comments"`
 }
 
-func (s *Service) performResolve(threadID, commit, host, owner, repo string) (ActionResult, error) {
+// FirstCommentID returns the node ID of the first comment in the thread, or empty string.
+func (d *threadDetails) FirstCommentID() string {
+	if len(d.Comments.Nodes) > 0 {
+		return d.Comments.Nodes[0].ID
+	}
+	return ""
+}
+
+func (s *Service) performResolve(threadID, commit, message, host, owner, repo string) (ActionResult, error) {
 	var replyBody string
+
+	// Post message reply first if provided (e.g. thumbs_down explanation)
+	if message != "" {
+		replyVars := map[string]interface{}{
+			"threadId": threadID,
+			"body":     message,
+		}
+		if err := s.API.GraphQL(addThreadReplyMutation, replyVars, nil); err != nil {
+			return ActionResult{}, fmt.Errorf("post message reply: %w", err)
+		}
+		replyBody = message
+	}
+
 	if commit != "" {
 		commitHost := host
 		if commitHost == "" {
 			commitHost = "github.com"
 		}
 		commitURL := fmt.Sprintf("https://%s/%s/%s/commit/%s", commitHost, owner, repo, commit)
-		replyBody = fmt.Sprintf("Addressed in [`%s`](%s)", commit, commitURL)
+		commitReply := fmt.Sprintf("Addressed in [`%s`](%s)", commit, commitURL)
 		replyVars := map[string]interface{}{
 			"threadId": threadID,
-			"body":     replyBody,
+			"body":     commitReply,
 		}
 		if err := s.API.GraphQL(addThreadReplyMutation, replyVars, nil); err != nil {
 			return ActionResult{}, fmt.Errorf("post commit reply: %w", err)
 		}
+		replyBody = commitReply
 	}
 
 	variables := map[string]interface{}{"threadId": threadID}
@@ -493,6 +539,9 @@ query ThreadDetails($id: ID!) {
       isResolved
       viewerCanResolve
       viewerCanUnresolve
+      comments(first: 1) {
+        nodes { id }
+      }
     }
   }
 }
@@ -529,3 +578,33 @@ mutation AddThreadReply($threadId: ID!, $body: String!) {
   }
 }
 `
+const addReactionMutation = `
+mutation AddReaction($subjectId: ID!, $content: ReactionContent!) {
+  addReaction(input: {subjectId: $subjectId, content: $content}) {
+    reaction {
+      content
+    }
+  }
+}
+`
+
+// ValidReactions maps CLI-friendly reaction names to GitHub GraphQL ReactionContent enum values.
+var ValidReactions = map[string]string{
+	"thumbs_up":   "THUMBS_UP",
+	"thumbs_down": "THUMBS_DOWN",
+	"laugh":       "LAUGH",
+	"hooray":      "HOORAY",
+	"confused":    "CONFUSED",
+	"heart":       "HEART",
+	"rocket":      "ROCKET",
+	"eyes":        "EYES",
+}
+
+// React adds a reaction to a comment identified by its node ID.
+func (s *Service) React(commentID, reaction string) error {
+	variables := map[string]interface{}{
+		"subjectId": commentID,
+		"content":   reaction,
+	}
+	return s.API.GraphQL(addReactionMutation, variables, nil)
+}

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -59,6 +59,7 @@ type ActionResult struct {
 	ThreadNodeID string `json:"thread_node_id"`
 	IsResolved   bool   `json:"is_resolved"`
 	ReplyBody    string `json:"reply_body,omitempty"`
+	Error        string `json:"error,omitempty"`
 }
 
 
@@ -82,9 +83,12 @@ func (s *Service) ResolveAll(pr resolver.Identity, opts ResolveAllOptions) ([]Ac
 
 	results := make([]ActionResult, 0, len(ts))
 	for _, t := range ts {
-		res, err := s.performResolve(t.ThreadID, strings.TrimSpace(opts.Commit), pr.Owner, pr.Repo)
+		res, err := s.changeResolution(pr, ActionOptions{
+			ThreadID: t.ThreadID,
+			Commit:   strings.TrimSpace(opts.Commit),
+		}, true)
 		if err != nil {
-			results = append(results, ActionResult{ThreadNodeID: t.ThreadID, IsResolved: false})
+			results = append(results, ActionResult{ThreadNodeID: t.ThreadID, IsResolved: false, Error: err.Error()})
 			continue
 		}
 		results = append(results, res)

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -136,7 +136,7 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 				latest = comment.UpdatedAt
 				hasStamp = true
 			}
-			if !authorMatched && comment.Author != nil && strings.ToLower(comment.Author.Login) == authorFilter {
+				if !authorMatched && comment.Author != nil && strings.Contains(strings.ToLower(comment.Author.Login), authorFilter) {
 				authorMatched = true
 			}
 		}

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -183,7 +183,7 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 			comments = append(comments, ThreadComment{
 				Author:    author,
 				Body:      c.Body,
-				CreatedAt: c.UpdatedAt.UTC().Format(time.RFC3339),
+				CreatedAt: c.UpdatedAt.UTC().Format(time.RFC3339), // GraphQL returns updatedAt; used as best proxy for comment time
 			})
 		}
 
@@ -374,7 +374,7 @@ func (s *Service) changeResolution(pr resolver.Identity, opts ActionOptions, res
 	}
 
 	if resolve {
-		return s.performResolve(threadID, strings.TrimSpace(opts.Commit), pr.Owner, pr.Repo)
+		return s.performResolve(threadID, strings.TrimSpace(opts.Commit), pr.Host, pr.Owner, pr.Repo)
 	}
 	return s.performUnresolve(threadID)
 }
@@ -400,10 +400,14 @@ type threadDetails struct {
 	ViewerCanUnresolve bool   `json:"viewerCanUnresolve"`
 }
 
-func (s *Service) performResolve(threadID, commit, owner, repo string) (ActionResult, error) {
+func (s *Service) performResolve(threadID, commit, host, owner, repo string) (ActionResult, error) {
 	var replyBody string
 	if commit != "" {
-		commitURL := fmt.Sprintf("https://github.com/%s/%s/commit/%s", owner, repo, commit)
+		commitHost := host
+		if commitHost == "" {
+			commitHost = "github.com"
+		}
+		commitURL := fmt.Sprintf("https://%s/%s/%s/commit/%s", commitHost, owner, repo, commit)
 		replyBody = fmt.Sprintf("Addressed in [`%s`](%s)", commit, commitURL)
 		replyVars := map[string]interface{}{
 			"threadId": threadID,

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -26,6 +26,7 @@ type ListOptions struct {
 	OnlyUnresolved bool
 	MineOnly       bool
 	Author         string
+	Since          time.Time // if non-zero, only include threads with updatedAt >= Since
 }
 
 // Thread represents a normalized review thread payload for JSON output.
@@ -142,6 +143,12 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 		if opts.MineOnly && !mine {
 			continue
 		}
+
+		// Since filter: skip threads whose latest comment is before the cutoff
+		if !opts.Since.IsZero() && (!hasStamp || latest.Before(opts.Since)) {
+			continue
+		}
+
 
 		var resolvedBy *string
 		if node.ResolvedBy != nil && node.ResolvedBy.Login != "" {

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -25,6 +25,7 @@ func NewService(api ghcli.API) *Service {
 type ListOptions struct {
 	OnlyUnresolved bool
 	MineOnly       bool
+	Author         string
 }
 
 // Thread represents a normalized review thread payload for JSON output.
@@ -41,6 +42,7 @@ type Thread struct {
 // ActionOptions controls resolve/unresolve operations.
 type ActionOptions struct {
 	ThreadID string
+	Commit   string
 }
 
 // ActionResult captures the outcome of a resolve/unresolve mutation.
@@ -79,6 +81,9 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 			hasStamp bool
 		)
 
+		authorFilter := strings.ToLower(strings.TrimSpace(opts.Author))
+		authorMatched := authorFilter == ""
+
 		for _, comment := range node.Comments.Nodes {
 			if comment.ViewerDidAuthor {
 				mine = true
@@ -87,6 +92,13 @@ func (s *Service) List(pr resolver.Identity, opts ListOptions) ([]Thread, error)
 				latest = comment.UpdatedAt
 				hasStamp = true
 			}
+			if !authorMatched && comment.Author != nil && strings.ToLower(comment.Author.Login) == authorFilter {
+				authorMatched = true
+			}
+		}
+
+		if !authorMatched {
+			continue
 		}
 
 		if opts.MineOnly && !mine {
@@ -182,6 +194,9 @@ type threadNode struct {
 			ViewerDidAuthor bool      `json:"viewerDidAuthor"`
 			UpdatedAt       time.Time `json:"updatedAt"`
 			DatabaseID      int64     `json:"databaseId"`
+			Author          *struct {
+				Login string `json:"login"`
+			} `json:"author"`
 		} `json:"nodes"`
 	} `json:"comments"`
 }
@@ -293,7 +308,7 @@ func (s *Service) changeResolution(pr resolver.Identity, opts ActionOptions, res
 	}
 
 	if resolve {
-		return s.performResolve(threadID)
+		return s.performResolve(threadID, strings.TrimSpace(opts.Commit))
 	}
 	return s.performUnresolve(threadID)
 }
@@ -319,7 +334,18 @@ type threadDetails struct {
 	ViewerCanUnresolve bool   `json:"viewerCanUnresolve"`
 }
 
-func (s *Service) performResolve(threadID string) (ActionResult, error) {
+func (s *Service) performResolve(threadID, commit string) (ActionResult, error) {
+	if commit != "" {
+		body := fmt.Sprintf("Addressed in `%s`", commit)
+		replyVars := map[string]interface{}{
+			"threadId": threadID,
+			"body":     body,
+		}
+		if err := s.API.GraphQL(addThreadReplyMutation, replyVars, nil); err != nil {
+			return ActionResult{}, fmt.Errorf("post commit reply: %w", err)
+		}
+	}
+
 	variables := map[string]interface{}{"threadId": threadID}
 	var resp struct {
 		Resolve struct {
@@ -370,6 +396,7 @@ query Threads($id: ID!, $after: String) {
               databaseId
               viewerDidAuthor
               updatedAt
+              author { login }
             }
           }
         }
@@ -413,6 +440,16 @@ mutation UnresolveThread($threadId: ID!) {
     thread {
       id
       isResolved
+    }
+  }
+}
+`
+
+const addThreadReplyMutation = `
+mutation AddThreadReply($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
+    comment {
+      id
     }
   }
 }

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -551,3 +551,124 @@ func assign(dst interface{}, payload interface{}) error {
 	}
 	return json.Unmarshal(data, dst)
 }
+
+
+// ─── F2: ResolveAll tests ─────────────────────────────────────────────────────
+
+func TestResolveAllResolvesUnresolvedThreads(t *testing.T) {
+	svc := &Service{}
+	var resolvedIDs []string
+
+	svc.API = &fakeAPI{
+		restFunc: restStub(t, "octo", "demo", "octo/demo", 7, "PR_bulk", nil),
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			switch query {
+			case listThreadsQuery:
+				ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+				return assign(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"reviewThreads": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "TA", "isResolved": false, "isOutdated": false, "path": "a.go",
+									"viewerCanResolve": true, "viewerCanUnresolve": false,
+									"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+										{"viewerDidAuthor": false, "updatedAt": ts, "databaseId": 1},
+									}},
+								},
+								{
+									"id": "TB", "isResolved": false, "isOutdated": false, "path": "b.go",
+									"viewerCanResolve": true, "viewerCanUnresolve": false,
+									"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+										{"viewerDidAuthor": false, "updatedAt": ts, "databaseId": 2},
+									}},
+								},
+							},
+							"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+						},
+					},
+				})
+			case resolveThreadMutation:
+				threadID := variables["threadId"].(string)
+				resolvedIDs = append(resolvedIDs, threadID)
+				return assign(result, map[string]interface{}{
+					"resolveReviewThread": map[string]interface{}{
+						"thread": map[string]interface{}{"id": threadID, "isResolved": true},
+					},
+				})
+			default:
+				return errors.New("unexpected query")
+			}
+		},
+	}
+
+	identity := resolver.Identity{Owner: "octo", Repo: "demo", Number: 7}
+	results, err := svc.ResolveAll(identity, ResolveAllOptions{Unresolved: true})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.ElementsMatch(t, []string{"TA", "TB"}, resolvedIDs)
+	for _, r := range results {
+		assert.True(t, r.IsResolved)
+	}
+}
+
+func TestResolveAllContinuesOnError(t *testing.T) {
+	svc := &Service{}
+
+	svc.API = &fakeAPI{
+		restFunc: restStub(t, "octo", "demo", "octo/demo", 8, "PR_err", nil),
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			switch query {
+			case listThreadsQuery:
+				ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+				return assign(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"reviewThreads": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "T_fail", "isResolved": false, "isOutdated": false, "path": "x.go",
+									"viewerCanResolve": true, "viewerCanUnresolve": false,
+									"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+										{"viewerDidAuthor": false, "updatedAt": ts, "databaseId": 10},
+									}},
+								},
+								{
+									"id": "T_ok", "isResolved": false, "isOutdated": false, "path": "y.go",
+									"viewerCanResolve": true, "viewerCanUnresolve": false,
+									"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+										{"viewerDidAuthor": false, "updatedAt": ts, "databaseId": 11},
+									}},
+								},
+							},
+							"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+						},
+					},
+				})
+			case resolveThreadMutation:
+				threadID := variables["threadId"].(string)
+				if threadID == "T_fail" {
+					return errors.New("server error")
+				}
+				return assign(result, map[string]interface{}{
+					"resolveReviewThread": map[string]interface{}{
+						"thread": map[string]interface{}{"id": threadID, "isResolved": true},
+					},
+				})
+			default:
+				return errors.New("unexpected query")
+			}
+		},
+	}
+
+	identity := resolver.Identity{Owner: "octo", Repo: "demo", Number: 8}
+	results, err := svc.ResolveAll(identity, ResolveAllOptions{Unresolved: true})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byID := map[string]ActionResult{}
+	for _, r := range results {
+		byID[r.ThreadNodeID] = r
+	}
+	assert.False(t, byID["T_fail"].IsResolved)
+	assert.True(t, byID["T_ok"].IsResolved)
+}

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -412,6 +412,138 @@ func TestUnresolveMutatesThread(t *testing.T) {
 	assert.Equal(t, "T9", res.ThreadNodeID)
 }
 
+// ─── Tests for --commit (reply-then-resolve) ────────────────────────────────
+
+func TestResolveWithCommitPostsReplyThenResolves(t *testing.T) {
+	svc := &Service{}
+	var calls []string
+	var replyBody string
+
+	svc.API = &fakeAPI{
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			switch query {
+			case threadDetailsQuery:
+				payload := map[string]interface{}{
+					"node": map[string]interface{}{
+						"id":                 "T1",
+						"isResolved":         false,
+						"viewerCanResolve":   true,
+						"viewerCanUnresolve": false,
+					},
+				}
+				return assign(result, payload)
+			case addThreadReplyMutation:
+				calls = append(calls, "reply")
+				replyBody = variables["body"].(string)
+				return nil
+			case resolveThreadMutation:
+				calls = append(calls, "resolve")
+				payload := map[string]interface{}{
+					"resolveReviewThread": map[string]interface{}{
+						"thread": map[string]interface{}{
+							"id":         "T1",
+							"isResolved": true,
+						},
+					},
+				}
+				return assign(result, payload)
+			default:
+				return errors.New("unexpected query")
+			}
+		},
+	}
+
+	_, err := svc.Resolve(resolver.Identity{Owner: "o", Repo: "r", Number: 1}, ActionOptions{
+		ThreadID: "T1",
+		Commit:   "abc123",
+	})
+	require.NoError(t, err)
+	// Must call reply BEFORE resolve — order matters
+	require.Equal(t, []string{"reply", "resolve"}, calls)
+	require.Equal(t, "Addressed in `abc123`", replyBody)
+}
+
+func TestResolveWithCommitBailsOnReplyFailure(t *testing.T) {
+	svc := &Service{}
+	resolveCalled := false
+
+	svc.API = &fakeAPI{
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			switch query {
+			case threadDetailsQuery:
+				payload := map[string]interface{}{
+					"node": map[string]interface{}{
+						"id":                 "T1",
+						"isResolved":         false,
+						"viewerCanResolve":   true,
+						"viewerCanUnresolve": false,
+					},
+				}
+				return assign(result, payload)
+			case addThreadReplyMutation:
+				return errors.New("reply failed: forbidden")
+			case resolveThreadMutation:
+				resolveCalled = true
+				return nil
+			default:
+				return errors.New("unexpected query")
+			}
+		},
+	}
+
+	_, err := svc.Resolve(resolver.Identity{Owner: "o", Repo: "r", Number: 1}, ActionOptions{
+		ThreadID: "T1",
+		Commit:   "abc123",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "post commit reply")
+	require.False(t, resolveCalled, "resolve must NOT be called when reply fails")
+}
+
+func TestResolveWithoutCommitSkipsReply(t *testing.T) {
+	svc := &Service{}
+	var calls []string
+
+	svc.API = &fakeAPI{
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			switch query {
+			case threadDetailsQuery:
+				calls = append(calls, "details")
+				payload := map[string]interface{}{
+					"node": map[string]interface{}{
+						"id":                 "T1",
+						"isResolved":         false,
+						"viewerCanResolve":   true,
+						"viewerCanUnresolve": false,
+					},
+				}
+				return assign(result, payload)
+			case resolveThreadMutation:
+				calls = append(calls, "resolve")
+				payload := map[string]interface{}{
+					"resolveReviewThread": map[string]interface{}{
+						"thread": map[string]interface{}{
+							"id":         "T1",
+							"isResolved": true,
+						},
+					},
+				}
+				return assign(result, payload)
+			default:
+				return errors.New("unexpected query: " + query[:40])
+			}
+		},
+	}
+
+	_, err := svc.Resolve(resolver.Identity{Owner: "o", Repo: "r", Number: 1}, ActionOptions{
+		ThreadID: "T1",
+		Commit:   "", // no commit
+	})
+	require.NoError(t, err)
+	// Should be details → resolve, NO reply call
+	require.Equal(t, []string{"details", "resolve"}, calls)
+}
+
 func assign(dst interface{}, payload interface{}) error {
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -460,7 +460,7 @@ func TestResolveWithCommitPostsReplyThenResolves(t *testing.T) {
 	require.NoError(t, err)
 	// Must call reply BEFORE resolve — order matters
 	require.Equal(t, []string{"reply", "resolve"}, calls)
-	require.Equal(t, "Addressed in `abc123`", replyBody)
+	require.Equal(t, "Addressed in [`abc123`](https://github.com/o/r/commit/abc123)", replyBody)
 }
 
 func TestResolveWithCommitBailsOnReplyFailure(t *testing.T) {

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"strconv"
-	"testing"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/agynio/gh-pr-review/internal/resolver"
@@ -553,7 +553,6 @@ func assign(dst interface{}, payload interface{}) error {
 	return json.Unmarshal(data, dst)
 }
 
-
 // ─── F2: ResolveAll tests ─────────────────────────────────────────────────────
 
 func TestResolveAllResolvesUnresolvedThreads(t *testing.T) {
@@ -692,6 +691,74 @@ func TestResolveAllContinuesOnError(t *testing.T) {
 	}
 	assert.False(t, byID["T_fail"].IsResolved)
 	assert.True(t, byID["T_ok"].IsResolved)
+}
+
+func TestResolveAllIncludeResolvedStillPostsCommitReply(t *testing.T) {
+	svc := &Service{}
+	var calls []string
+	var replyBody string
+
+	svc.API = &fakeAPI{
+		restFunc: restStub(t, "octo", "demo", "octo/demo", 9, "PR_resolved", nil),
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			switch query {
+			case listThreadsQuery:
+				ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+				return assign(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"reviewThreads": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "T_done", "isResolved": true, "isOutdated": false, "path": "done.go",
+									"viewerCanResolve": false, "viewerCanUnresolve": true,
+									"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+										{"viewerDidAuthor": false, "updatedAt": ts, "databaseId": 42},
+									}},
+								},
+							},
+							"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+						},
+					},
+				})
+			case threadDetailsQuery:
+				calls = append(calls, "details")
+				return assign(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"id":                 "T_done",
+						"isResolved":         true,
+						"viewerCanResolve":   false,
+						"viewerCanUnresolve": true,
+						"comments": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{"id": "C_done"},
+							},
+						},
+					},
+				})
+			case addThreadReplyMutation:
+				calls = append(calls, "reply")
+				replyBody, _ = variables["body"].(string)
+				return nil
+			case resolveThreadMutation:
+				calls = append(calls, "resolve")
+				return nil
+			default:
+				return errors.New("unexpected query")
+			}
+		},
+	}
+
+	identity := resolver.Identity{Host: "github.com", Owner: "octo", Repo: "demo", Number: 9}
+	results, err := svc.ResolveAll(identity, ResolveAllOptions{
+		Commit:     "abc1234",
+		Unresolved: false,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "T_done", results[0].ThreadNodeID)
+	assert.True(t, results[0].IsResolved)
+	assert.Equal(t, []string{"details", "reply"}, calls)
+	assert.Contains(t, replyBody, "abc1234")
 }
 
 // ─── F3: --since filter test ──────────────────────────────────────────────────
@@ -987,4 +1054,3 @@ func TestResolveWithReactSkipsReactionWhenNoComments(t *testing.T) {
 	assert.False(t, reactCalled, "reaction should NOT be called when thread has no comments")
 	assert.True(t, result.IsResolved)
 }
-

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -940,3 +940,51 @@ func TestResolveAllErrorFieldPopulated(t *testing.T) {
 	assert.False(t, results[0].IsResolved)
 	assert.Contains(t, results[0].Error, "cannot resolve")
 }
+func TestResolveWithReactSkipsReactionWhenNoComments(t *testing.T) {
+	svc := &Service{}
+	resolveCalled := false
+	reactCalled := false
+	svc.API = &fakeAPI{
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			switch {
+			case query == threadDetailsQuery:
+				return assign(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"id":                 "T_empty",
+						"isResolved":         false,
+						"viewerCanResolve":   true,
+						"viewerCanUnresolve": false,
+						"comments": map[string]interface{}{
+							"nodes": []map[string]interface{}{},
+						},
+					},
+				})
+			case query == resolveThreadMutation:
+				resolveCalled = true
+				return assign(result, map[string]interface{}{
+					"resolveReviewThread": map[string]interface{}{
+						"thread": map[string]interface{}{
+							"id":         "T_empty",
+							"isResolved": true,
+						},
+					},
+				})
+			case strings.Contains(query, "addReaction"):
+				reactCalled = true
+				return nil
+			default:
+				return errors.New("unexpected query")
+			}
+		},
+	}
+
+	result, err := svc.Resolve(resolver.Identity{Host: "github.com"}, ActionOptions{
+		ThreadID: "T_empty",
+		React:    "THUMBS_UP",
+	})
+	require.NoError(t, err)
+	assert.True(t, resolveCalled, "resolve mutation should be called")
+	assert.False(t, reactCalled, "reaction should NOT be called when thread has no comments")
+	assert.True(t, result.IsResolved)
+}
+

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 	"testing"
+	"strings"
 	"time"
 
 	"github.com/agynio/gh-pr-review/internal/resolver"
@@ -716,4 +717,78 @@ func TestServiceListSinceFiltersOldThreads(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "T_recent", results[0].ThreadID)
+}
+
+func TestResolveIncludesReplyBodyWhenCommitProvided(t *testing.T) {
+	api := &fakeAPI{}
+	api.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		switch {
+		case strings.Contains(query, "ThreadDetails"):
+			return assign(result, map[string]interface{}{
+				"node": map[string]interface{}{
+					"id":                 "T_commit",
+					"isResolved":         false,
+					"viewerCanResolve":   true,
+					"viewerCanUnresolve": false,
+				},
+			})
+		case strings.Contains(query, "addPullRequestReviewThreadReply"):
+			// reply mutation — result is nil, just succeed
+			return nil
+		case strings.Contains(query, "resolveReviewThread"):
+			return assign(result, map[string]interface{}{
+				"resolveReviewThread": map[string]interface{}{
+					"thread": map[string]interface{}{
+						"id":         "T_commit",
+						"isResolved": true,
+					},
+				},
+			})
+		default:
+			return errors.New("unexpected query")
+		}
+	}
+
+	svc := NewService(api)
+	identity := resolver.Identity{Owner: "octo", Repo: "demo", Number: 1}
+	result, err := svc.Resolve(identity, ActionOptions{ThreadID: "T_commit", Commit: "abc1234"})
+	require.NoError(t, err)
+	assert.Equal(t, "T_commit", result.ThreadNodeID)
+	assert.True(t, result.IsResolved)
+	assert.Contains(t, result.ReplyBody, "abc1234")
+	assert.Contains(t, result.ReplyBody, "octo/demo/commit/abc1234")
+}
+
+func TestResolveNoReplyBodyWhenNoCommit(t *testing.T) {
+	api := &fakeAPI{}
+	api.graphqlFunc = func(query string, variables map[string]interface{}, result interface{}) error {
+		switch {
+		case strings.Contains(query, "ThreadDetails"):
+			return assign(result, map[string]interface{}{
+				"node": map[string]interface{}{
+					"id":                 "T_no_commit",
+					"isResolved":         false,
+					"viewerCanResolve":   true,
+					"viewerCanUnresolve": false,
+				},
+			})
+		case strings.Contains(query, "resolveReviewThread"):
+			return assign(result, map[string]interface{}{
+				"resolveReviewThread": map[string]interface{}{
+					"thread": map[string]interface{}{
+						"id":         "T_no_commit",
+						"isResolved": true,
+					},
+				},
+			})
+		default:
+			return errors.New("unexpected query")
+		}
+	}
+
+	svc := NewService(api)
+	identity := resolver.Identity{Owner: "octo", Repo: "demo", Number: 1}
+	result, err := svc.Resolve(identity, ActionOptions{ThreadID: "T_no_commit"})
+	require.NoError(t, err)
+	assert.Empty(t, result.ReplyBody)
 }

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -812,3 +812,131 @@ func TestResolveNoReplyBodyWhenNoCommit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ReplyBody)
 }
+
+// ─── Author substring matching tests ─────────────────────────────────────────
+
+func TestServiceListAuthorSubstringMatch(t *testing.T) {
+	svc := &Service{}
+	svc.API = &fakeAPI{
+		restFunc: restStub(t, "octo", "demo", "octo/demo", 9, "PR_sub", nil),
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			require.Equal(t, listThreadsQuery, query)
+			ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			return assign(result, map[string]interface{}{
+				"node": map[string]interface{}{
+					"reviewThreads": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{
+								"id": "T_rabbit", "isResolved": false, "isOutdated": false, "path": "a.go",
+								"viewerCanResolve": true, "viewerCanUnresolve": false,
+								"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+									{"viewerDidAuthor": false, "updatedAt": ts, "databaseId": 1, "body": "nitpick", "author": map[string]interface{}{"login": "coderabbitai"}},
+								}},
+							},
+							{
+								"id": "T_codex", "isResolved": false, "isOutdated": false, "path": "b.go",
+								"viewerCanResolve": true, "viewerCanUnresolve": false,
+								"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+									{"viewerDidAuthor": false, "updatedAt": ts, "databaseId": 2, "body": "bug", "author": map[string]interface{}{"login": "chatgpt-codex-connector"}},
+								}},
+							},
+							{
+								"id": "T_human", "isResolved": false, "isOutdated": false, "path": "c.go",
+								"viewerCanResolve": true, "viewerCanUnresolve": false,
+								"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+									{"viewerDidAuthor": false, "updatedAt": ts, "databaseId": 3, "body": "looks good", "author": map[string]interface{}{"login": "reviewer42"}},
+								}},
+							},
+						},
+						"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+					},
+				},
+			})
+		},
+	}
+
+	identity := resolver.Identity{Owner: "octo", Repo: "demo", Number: 9}
+
+	// Substring "codex" should match "chatgpt-codex-connector"
+	t.Run("substring matches partial login", func(t *testing.T) {
+		results, err := svc.List(identity, ListOptions{Author: "codex"})
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "T_codex", results[0].ThreadID)
+	})
+
+	// Substring "rabbit" should match "coderabbitai"
+	t.Run("substring matches coderabbitai", func(t *testing.T) {
+		results, err := svc.List(identity, ListOptions{Author: "rabbit"})
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "T_rabbit", results[0].ThreadID)
+	})
+
+	// Substring "CODEX" should match case-insensitively
+	t.Run("substring is case insensitive", func(t *testing.T) {
+		results, err := svc.List(identity, ListOptions{Author: "CODEX"})
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "T_codex", results[0].ThreadID)
+	})
+
+	// Substring "nobody" should match nothing
+	t.Run("non-matching substring returns empty", func(t *testing.T) {
+		results, err := svc.List(identity, ListOptions{Author: "nobody"})
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+	})
+
+	// No author filter returns all
+	t.Run("empty author returns all threads", func(t *testing.T) {
+		results, err := svc.List(identity, ListOptions{})
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+	})
+}
+
+func TestResolveAllErrorFieldPopulated(t *testing.T) {
+	svc := &Service{}
+	svc.API = &fakeAPI{
+		restFunc: restStub(t, "octo", "demo", "octo/demo", 10, "PR_errfield", nil),
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			switch query {
+			case listThreadsQuery:
+				return assign(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"reviewThreads": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "T_ok", "isResolved": false, "isOutdated": false, "path": "x.go",
+									"viewerCanResolve": true, "viewerCanUnresolve": false,
+									"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+										{"viewerDidAuthor": false, "updatedAt": ts, "databaseId": 1},
+									}},
+								},
+							},
+							"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+						},
+					},
+				})
+			case threadDetailsQuery:
+				return assign(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"id": "T_ok", "isResolved": false,
+						"viewerCanResolve": false, "viewerCanUnresolve": false,
+					},
+				})
+			default:
+				return errors.New("unexpected query")
+			}
+		},
+	}
+
+	identity := resolver.Identity{Owner: "octo", Repo: "demo", Number: 10}
+	results, err := svc.ResolveAll(identity, ResolveAllOptions{Unresolved: true})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.False(t, results[0].IsResolved)
+	assert.Contains(t, results[0].Error, "cannot resolve")
+}

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -589,6 +589,16 @@ func TestResolveAllResolvesUnresolvedThreads(t *testing.T) {
 						},
 					},
 				})
+			case threadDetailsQuery:
+				threadID := variables["id"].(string)
+				return assign(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"id":                 threadID,
+						"isResolved":         false,
+						"viewerCanResolve":   true,
+						"viewerCanUnresolve": false,
+					},
+				})
 			case resolveThreadMutation:
 				threadID := variables["threadId"].(string)
 				resolvedIDs = append(resolvedIDs, threadID)
@@ -643,6 +653,16 @@ func TestResolveAllContinuesOnError(t *testing.T) {
 							},
 							"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
 						},
+					},
+				})
+			case threadDetailsQuery:
+				threadID := variables["id"].(string)
+				return assign(result, map[string]interface{}{
+					"node": map[string]interface{}{
+						"id":                 threadID,
+						"isResolved":         false,
+						"viewerCanResolve":   true,
+						"viewerCanUnresolve": false,
 					},
 				})
 			case resolveThreadMutation:

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -672,3 +672,48 @@ func TestResolveAllContinuesOnError(t *testing.T) {
 	assert.False(t, byID["T_fail"].IsResolved)
 	assert.True(t, byID["T_ok"].IsResolved)
 }
+
+// ─── F3: --since filter test ──────────────────────────────────────────────────
+
+func TestServiceListSinceFiltersOldThreads(t *testing.T) {
+	svc := &Service{}
+
+	old := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cutoff := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	svc.API = &fakeAPI{
+		restFunc: restStub(t, "octo", "demo", "octo/demo", 9, "PR_since", nil),
+		graphqlFunc: func(query string, variables map[string]interface{}, result interface{}) error {
+			return assign(result, map[string]interface{}{
+				"node": map[string]interface{}{
+					"reviewThreads": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{
+								"id": "T_old", "isResolved": false, "isOutdated": false, "path": "old.go",
+								"viewerCanResolve": false, "viewerCanUnresolve": false,
+								"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+									{"viewerDidAuthor": false, "updatedAt": old, "databaseId": 1},
+								}},
+							},
+							{
+								"id": "T_recent", "isResolved": false, "isOutdated": false, "path": "new.go",
+								"viewerCanResolve": false, "viewerCanUnresolve": false,
+								"comments": map[string]interface{}{"nodes": []map[string]interface{}{
+									{"viewerDidAuthor": false, "updatedAt": recent, "databaseId": 2},
+								}},
+							},
+						},
+						"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+					},
+				},
+			})
+		},
+	}
+
+	identity := resolver.Identity{Owner: "octo", Repo: "demo", Number: 9}
+	results, err := svc.List(identity, ListOptions{Since: cutoff})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "T_recent", results[0].ThreadID)
+}


### PR DESCRIPTION
## Problem

GitHub CLI has no way to list, filter, or resolve inline PR review threads programmatically. Agents receiving hundreds of review comments have zero triage tooling. Open request since [cli/cli#359](https://github.com/cli/cli/issues/359) (6+ years).

## Real-World Evidence

Stress-tested on nightfox-agent PR #18: **178 review threads** across three automated reviewers (CodeRabbit, Codex, humans).

## What's New

### `gh pr-review react` — standalone reaction command

Decoupled from thread resolution. Works on **any reactable GitHub node** — review bodies, thread comments, issue comments. Agents can signal acknowledgment or flag issues without resolving anything.

```sh
gh pr-review react PRR_kwDO... --type rocket
gh pr-review react IC_kwDO... --type eyes
# All 8: thumbs_up, thumbs_down, laugh, hooray, confused, heart, rocket, eyes
```

**Why:** Our agents needed to signal "I've seen this" on review comments without being forced to resolve threads. Locking reactions behind resolve was like putting a doorknob only on the inside. Now agents can react independently — useful for multi-agent workflows where one agent triages and another acts.

### `--react` + `--message` on `threads resolve`

Reactions also work inline during resolution as convenience:

```sh
gh pr-review threads resolve 18 --thread-id PRRT_xxx --commit HEAD --react thumbs_up
gh pr-review threads resolve 18 --thread-id PRRT_xxx --react thumbs_down --message "False positive"
```

**Validation gate:** resolve requires `--commit` or `--react thumbs_down`. No silent resolves.

### `--author` — substring match, case-insensitive

```sh
gh pr-review threads list 18 -R owner/repo --author rabbit   # matches coderabbitai
gh pr-review threads list 18 -R owner/repo --author codex    # matches chatgpt-codex-connector
```

### `--commit` on resolve — atomic reply + resolve

Posts "Addressed in [abc1234](link)" then resolves. Reply failure = thread stays open.

### `threads resolve-all` — bulk resolution

```sh
gh pr-review threads resolve-all 18 -R owner/repo --author rabbit --commit abc1234
```

### Other improvements

- `--since`: filter threads by update time
- `-o ids`: bare thread IDs for piping
- `--include-resolved`: show resolved threads
- GHE support: correct host in commit URLs
- Git ref resolution: `--commit HEAD` resolves to short SHA

## Bug Fixes (contributed by @Cwilliams333)

Three bugs were identified and fixed via [lliWcWill/gh-pr-review#1](https://github.com/lliWcWill/gh-pr-review/pull/1):

### 1. Symbolic git ref injection in `resolveCommitRef`
`--commit HEAD` or `--commit branch-name` used `git rev-parse --short -- ref` which could resolve to trees/blobs instead of commits, and `--` didn't properly guard against ref interpretation. Fixed to use `git rev-parse --verify --short --end-of-options ref^{commit}` — ensures single commit output only. Added empty-ref guard.

### 2. `--author` exact match vs substring inconsistency
`review view --author` used exact-match (`==`) while `threads list --author` used substring match (`strings.Contains`). This meant `--author codex` would match in `threads list` but fail silently in `review view`. Fixed `BuildReport` to use substring matching, consistent with `threads list`.

### 3. `resolve-all --include-resolved` silently skipping already-resolved threads
When using `resolve-all` with `--include-resolved` and `--commit`, already-resolved threads were early-returned without posting the commit breadcrumb reply. Fixed by allowing the resolve path to proceed (posting reply + reaction) while skipping the actual resolve mutation when the thread is already in the desired state.

All three fixes include corresponding unit tests.

## Test plan

- [x] 35+ tests across all packages, zero failures
- [x] Live-tested on nightfox-agent PR #18 (178 threads, 3 reviewers)
- [x] `react` live-tested: rocket + eyes on Codex review bodies
- [x] Empty-comments null pointer guard tested (RC catch)
- [x] Author substring: 5 subtests (exact, partial, case-insensitive)
- [x] Validation gate: reject resolve without commit or thumbs_down
- [x] Symbolic ref resolution: HEAD + branch name tests
- [x] resolve-all --include-resolved: commit breadcrumb on already-resolved threads
- [x] Build clean, vet clean, no cache